### PR TITLE
Colors audit

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 					$message = __( '<b>Warning!</b> Your %s license is inactive which means you\'re missing out on updates and support! <a href="%s">Activate your license</a> or <a href="%s" target="_blank">get a license here</a>.' );
 				}
 				?>
-				<div class="error">
+				<div class="notice notice-error yoast-notice-error">
 					<p><?php printf( __( $message, $this->product->get_text_domain() ), $this->product->get_item_name(), $this->product->get_license_page_url(), $this->product->get_tracking_url( 'activate-license-notice' ) ); ?></p>
 				</div>
 			<?php
@@ -130,7 +130,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 				if ( ! defined( "WP_ACCESSIBLE_HOSTS" ) || stristr( WP_ACCESSIBLE_HOSTS, $host ) === false ) {
 					?>
-					<div class="error">
+					<div class="notice notice-error yoast-notice-error">
 						<p><?php printf( __( '<b>Warning!</b> You\'re blocking external requests which means you won\'t be able to get %s updates. Please add %s to %s.', $this->product->get_text_domain() ), $this->product->get_item_name(), '<strong>' . $host . '</strong>', '<code>WP_ACCESSIBLE_HOSTS</code>' ); ?></p>
 					</div>
 				<?php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		 * @param string $message The message to display
 		 */
 		protected function set_notice( $message, $success = true ) {
-			$css_class = ( $success ) ? 'updated' : 'error';
+			$css_class = ( $success ) ? 'notice-success yoast-notice-success' : 'notice-error yoast-notice-error';
 			add_settings_error( $this->prefix . 'license', 'license-notice', $message, $css_class );
 		}
 

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -75,7 +75,7 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 			}
 
 			?>
-			<div class="error">
+			<div class="notice notice-error yoast-notice-error">
 				<p><?php printf( __( '%s failed to check for updates because of the following error: <em>%s</em>', $this->product->get_text_domain() ), $this->product->get_item_name(), $this->error_message ); ?></p>
 			</div>
 			<?php

--- a/views/form.php
+++ b/views/form.php
@@ -30,10 +30,10 @@ wp_nonce_field( $nonce_name, $nonce_name ); ?>
 		<tr valign="top">
 			<th scope="row" valign="top"><?php _e( 'License status', $product->get_text_domain() ); ?></th>
 			<td>
-				<?php if( $this->license_is_valid() ) { ?>
-				<span style="padding: 3px 6px; color: #fff; background: #008a00;"><?php _e( 'ACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are receiving updates.', $product->get_text_domain() ); ?>
+				<?php if ( $this->license_is_valid() ) { ?>
+				<span class="yoast-license-status-active"><?php _e( 'ACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are receiving updates.', $product->get_text_domain() ); ?>
 				<?php } else { ?>
-				<span style="padding: 3px 6px; color: #fff; background: #dc3232;"><?php _e( 'INACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are <strong>not</strong> receiving updates.', $product->get_text_domain() ); ?>
+				<span class="yoast-license-status-inactive"><?php _e( 'INACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are <strong>not</strong> receiving updates.', $product->get_text_domain() ); ?>
 				<?php } ?>
 			</td>
 		</tr>

--- a/views/form.php
+++ b/views/form.php
@@ -12,11 +12,11 @@ $product = $this->product;
 $this->show_license_form_heading();
 
 if( $api_host_available['availability'] === false ){
-	echo '<p style="color: #dc3232; max-width: 600px;"><strong>' . sprintf( __( 'We couldn\'t create a connection to our API to verify your license key(s). Please ask your hosting company to allow outgoing connections from your server to %s.', $product->get_text_domain() ), $api_host_available['url'] ) . '</strong></p>';
+	echo '<div class="notice notice-error inline yoast-notice-error"><p>' . sprintf( __( 'We couldn\'t create a connection to our API to verify your license key(s). Please ask your hosting company to allow outgoing connections from your server to %s.', $product->get_text_domain() ), $api_host_available['url'] ) . '</p></div>';
 }
 
 if( $api_host_available['curl_version'] !== false && version_compare( $api_host_available['curl_version'], '7.20.0', '<')){
-	echo '<p style="color: #dc3232; max-width: 600px;"><strong>' . sprintf( __( 'Your server has an outdated version of the PHP module cURL (Version: %s). Please ask your hosting company to update this to a recent version of cURL. You can read more about that in our %sKnowledge base%s.', $product->get_text_domain() ), $api_host_available['curl_version'], '<a href="http://kb.yoast.com/article/90-is-my-curl-up-to-date" target="_blank">', '</a>' ) . '</strong></p>';
+	echo '<div class="notice notice-error inline yoast-notice-error"><p>' . sprintf( __( 'Your server has an outdated version of the PHP module cURL (Version: %s). Please ask your hosting company to update this to a recent version of cURL. You can read more about that in our %sKnowledge base%s.', $product->get_text_domain() ), $api_host_available['curl_version'], '<a href="http://kb.yoast.com/article/90-is-my-curl-up-to-date" target="_blank">', '</a>' ) . '</p></div>';
 }
 
 // Output form tags if we're not embedded in another form

--- a/views/form.php
+++ b/views/form.php
@@ -12,11 +12,11 @@ $product = $this->product;
 $this->show_license_form_heading();
 
 if( $api_host_available['availability'] === false ){
-	echo '<p style="color: red; max-width: 600px;"><strong>' . sprintf( __( 'We couldn\'t create a connection to our API to verify your license key(s). Please ask your hosting company to allow outgoing connections from your server to %s.', $product->get_text_domain() ), $api_host_available['url'] ) . '</strong></p>';
+	echo '<p style="color: #dc3232; max-width: 600px;"><strong>' . sprintf( __( 'We couldn\'t create a connection to our API to verify your license key(s). Please ask your hosting company to allow outgoing connections from your server to %s.', $product->get_text_domain() ), $api_host_available['url'] ) . '</strong></p>';
 }
 
 if( $api_host_available['curl_version'] !== false && version_compare( $api_host_available['curl_version'], '7.20.0', '<')){
-	echo '<p style="color: red; max-width: 600px;"><strong>' . sprintf( __( 'Your server has an outdated version of the PHP module cURL (Version: %s). Please ask your hosting company to update this to a recent version of cURL. You can read more about that in our %sKnowledge base%s.', $product->get_text_domain() ), $api_host_available['curl_version'], '<a href="http://kb.yoast.com/article/90-is-my-curl-up-to-date" target="_blank">', '</a>' ) . '</strong></p>';
+	echo '<p style="color: #dc3232; max-width: 600px;"><strong>' . sprintf( __( 'Your server has an outdated version of the PHP module cURL (Version: %s). Please ask your hosting company to update this to a recent version of cURL. You can read more about that in our %sKnowledge base%s.', $product->get_text_domain() ), $api_host_available['curl_version'], '<a href="http://kb.yoast.com/article/90-is-my-curl-up-to-date" target="_blank">', '</a>' ) . '</strong></p>';
 }
 
 // Output form tags if we're not embedded in another form
@@ -31,9 +31,9 @@ wp_nonce_field( $nonce_name, $nonce_name ); ?>
 			<th scope="row" valign="top"><?php _e( 'License status', $product->get_text_domain() ); ?></th>
 			<td>
 				<?php if( $this->license_is_valid() ) { ?>
-				<span style="color: white; background: limegreen; padding:3px 6px;"><?php _e( 'ACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are receiving updates.', $product->get_text_domain() ); ?>
+				<span style="padding: 3px 6px; color: #fff; background: #008a00;"><?php _e( 'ACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are receiving updates.', $product->get_text_domain() ); ?>
 				<?php } else { ?>
-				<span style="color:white; background: red; padding: 3px 6px;"><?php _e( 'INACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are <strong>not</strong> receiving updates.', $product->get_text_domain() ); ?>
+				<span style="padding: 3px 6px; color: #fff; background: #dc3232;"><?php _e( 'INACTIVE', $product->get_text_domain() ); ?></span> &nbsp; - &nbsp; <?php _e( 'you are <strong>not</strong> receiving updates.', $product->get_text_domain() ); ?>
 				<?php } ?>
 			</td>
 		</tr>


### PR DESCRIPTION
Part of the colors review effort:
- removes custom errors, use notices instead (see screenshots below)
- uses the new WP CSS classes for existing notices
- removes inline styles used for the "active/inactive" license status (needs new CSS rules and colors in wordpress-seo, will open an issue)

custom errors before:

![screen shot 2016-11-18 at 15 27 36](https://cloud.githubusercontent.com/assets/1682452/20437295/bcd75a22-adb3-11e6-9904-87ae10b65e3c.png)

custom errors after:

![screen shot 2016-11-18 at 15 37 28](https://cloud.githubusercontent.com/assets/1682452/20437296/bcdb620c-adb3-11e6-8c05-4ab12f63fefc.png)

active/inactive status better colors (needs separate PR on wordpress-seo):

![screen shot 2016-11-18 at 16 08 19](https://cloud.githubusercontent.com/assets/1682452/20437297/bcde6c04-adb3-11e6-976d-43521c82cd61.png)

Fixes #95 