### PR TITLE
Allow custom messages to be communicated from the server

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -683,7 +683,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 			// Make sure we limit the type of HTML elements to be displayed.
 			if ( ! empty( $message ) ) {
-				$message = strip_tags( $message, 'a' );
+				$message = strip_tags( $message, '<a>' );
 
 				// Make sure we are on a new line.
 				$message = '<br />' . $message;

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -202,7 +202,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 					$message = sprintf( __( "Failed to deactivate your %s license.", $this->product->get_text_domain() ), $this->product->get_item_name() );
 				}
 
-				$message .= wpautop( $this->get_custom_message( $result ) );
+				$message .= $this->get_custom_message( $result );
 
 				// Append custom HTML message to default message.
 				$this->set_notice( $message, $success );

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -648,11 +648,11 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
-		 * Get the relevant locale
+		 * Get the locale for the current user
 		 *
 		 * @return string
 		 */
-		protected function get_locale() {
+		protected function get_user_locale() {
 			if ( function_exists( 'get_user_locale' ) ) {
 				return get_user_locale();
 			}
@@ -671,14 +671,14 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			$message = '';
 
 			// Allow for translated messages to be used.
-			$localizedDescription = 'html_description_' . $this->get_locale();
+			$localizedDescription = 'custom_message_' . $this->get_user_locale();
 			if ( ! empty( $result->{$localizedDescription} ) ) {
 				$message = $result->{$localizedDescription};
 			}
 
-			// Fall back to default HTML Description if no locale has been provided.
-			if ( empty( $message ) && ! empty( $result->html_description ) ) {
-				$message = $result->html_description;
+			// Fall back to non-localized custom message if no locale has been provided.
+			if ( empty( $message ) && ! empty( $result->custom_message ) ) {
+				$message = $result->custom_message;
 			}
 
 			// Make sure we limit the type of HTML elements to be displayed.

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -4,6 +4,7 @@ if ( ! interface_exists( 'iYoast_License_Manager', false ) ) {
 
 	interface iYoast_License_Manager {
 		public function specific_hooks();
+
 		public function setup_auto_updater();
 	}
 
@@ -116,10 +117,10 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 					$message = __( '<b>Warning!</b> Your %s license is inactive which means you\'re missing out on updates and support! <a href="%s">Activate your license</a> or <a href="%s" target="_blank">get a license here</a>.' );
 				}
 				?>
-				<div class="notice notice-error yoast-notice-error">
-					<p><?php printf( __( $message, $this->product->get_text_domain() ), $this->product->get_item_name(), $this->product->get_license_page_url(), $this->product->get_tracking_url( 'activate-license-notice' ) ); ?></p>
-				</div>
-			<?php
+                <div class="notice notice-error yoast-notice-error">
+                    <p><?php printf( __( $message, $this->product->get_text_domain() ), $this->product->get_item_name(), $this->product->get_license_page_url(), $this->product->get_tracking_url( 'activate-license-notice' ) ); ?></p>
+                </div>
+				<?php
 			}
 
 			// show notice if external requests are blocked through the WP_HTTP_BLOCK_EXTERNAL constant
@@ -130,10 +131,10 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 				if ( ! defined( "WP_ACCESSIBLE_HOSTS" ) || stristr( WP_ACCESSIBLE_HOSTS, $host ) === false ) {
 					?>
-					<div class="notice notice-error yoast-notice-error">
-						<p><?php printf( __( '<b>Warning!</b> You\'re blocking external requests which means you won\'t be able to get %s updates. Please add %s to %s.', $this->product->get_text_domain() ), $this->product->get_item_name(), '<strong>' . $host . '</strong>', '<code>WP_ACCESSIBLE_HOSTS</code>' ); ?></p>
-					</div>
-				<?php
+                    <div class="notice notice-error yoast-notice-error">
+                        <p><?php printf( __( '<b>Warning!</b> You\'re blocking external requests which means you won\'t be able to get %s updates. Please add %s to %s.', $this->product->get_text_domain() ), $this->product->get_item_name(), '<strong>' . $host . '</strong>', '<code>WP_ACCESSIBLE_HOSTS</code>' ); ?></p>
+                    </div>
+					<?php
 				}
 
 			}
@@ -229,7 +230,8 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 				'edd_action' => $action . '_license',
 				'license'    => $this->get_license_key(),
 				'item_name'  => urlencode( trim( $this->product->get_item_name() ) ),
-				'url'        => get_option( 'home' )                                    // grab the URL straight from the option to prevent filters from breaking it.
+				'url'        => get_option( 'home' )
+				// grab the URL straight from the option to prevent filters from breaking it.
 			);
 
 			// create api request url
@@ -370,7 +372,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		protected function get_option( $name ) {
 			$options = $this->get_options();
 
-			return $options[$name];
+			return $options[ $name ];
 		}
 
 		/**
@@ -384,7 +386,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			$options = $this->get_options();
 
 			// update option
-			$options[$name] = $value;
+			$options[ $name ] = $value;
 
 			// save options
 			$this->set_options( $options );
@@ -392,10 +394,11 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 		public function show_license_form_heading() {
 			?>
-			<h3>
-				<?php printf( __( "%s: License Settings", $this->product->get_text_domain() ), $this->product->get_item_name() ); ?>&nbsp; &nbsp;
-			</h3>
-		<?php
+            <h3>
+				<?php printf( __( "%s: License Settings", $this->product->get_text_domain() ), $this->product->get_item_name() ); ?>
+                &nbsp; &nbsp;
+            </h3>
+			<?php
 		}
 
 		/**
@@ -436,7 +439,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			$name = $this->prefix . 'license_key';
 
 			// check if license key was posted and not empty
-			if ( ! isset( $_POST[$name] ) ) {
+			if ( ! isset( $_POST[ $name ] ) ) {
 				return;
 			}
 
@@ -450,13 +453,13 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			// @TODO: check for user cap?
 
 			// get key from posted value
-			$license_key = $_POST[$name];
+			$license_key = $_POST[ $name ];
 
 			// check if license key doesn't accidentally contain asterisks
 			if ( strstr( $license_key, '*' ) === false ) {
 
 				// sanitize key
-				$license_key = trim( sanitize_key( $_POST[$name] ) );
+				$license_key = trim( sanitize_key( $_POST[ $name ] ) );
 
 				// save license key
 				$this->set_license_key( $license_key );
@@ -473,9 +476,9 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			$action_name = $this->prefix . 'license_action';
 
 			// was one of the action buttons clicked?
-			if ( isset( $_POST[$action_name] ) ) {
+			if ( isset( $_POST[ $action_name ] ) ) {
 
-				$action = trim( $_POST[$action_name] );
+				$action = trim( $_POST[ $action_name ] );
 
 				switch ( $action ) {
 					case 'activate':
@@ -513,7 +516,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		 *
 		 * @return array
 		 */
-		protected function get_api_availability(){
+		protected function get_api_availability() {
 			return array(
 				'url'          => $this->product->get_api_url(),
 				'availability' => $this->check_api_host_availability(),
@@ -559,7 +562,10 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 			if ( empty( $this->license_constant_name ) ) {
 				// generate license constant name
-				$this->set_license_constant_name( strtoupper( str_replace( array( ' ', '-' ), '', sanitize_key( $this->product->get_item_name() ) ) ) . '_LICENSE' );
+				$this->set_license_constant_name( strtoupper( str_replace( array(
+						' ',
+						'-'
+					), '', sanitize_key( $this->product->get_item_name() ) ) ) . '_LICENSE' );
 			}
 
 			// set license key from constant
@@ -577,14 +583,14 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
-         * Determine what message should be shown for a successful license activation
-         *
+		 * Determine what message should be shown for a successful license activation
+		 *
 		 * @param Object $result Result of a request.
 		 *
 		 * @return string
 		 */
 		protected function get_successful_activation_message( $result ) {
-		    // Get expiry date.
+			// Get expiry date.
 			if ( isset( $result->expires ) ) {
 				$this->set_license_expiry_date( $result->expires );
 				$expiry_date = strtotime( $result->expires );
@@ -615,8 +621,8 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
-         * Determine what message should be shown for an unsuccessful activation
-         *
+		 * Determine what message should be shown for an unsuccessful activation
+		 *
 		 * @param Object $result Result of a request.
 		 *
 		 * @return string

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -610,11 +610,13 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 			// add upgrade notice if user has less than 3 activations left
 			if ( $result->license_limit > 0 && ( $result->license_limit - $result->site_count ) <= 3 ) {
-				$message .= sprintf( __( '<a href="%s">Did you know you can upgrade your license?</a>', $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-nearing-limit-notice' ) );
-			} elseif ( $expiry_date !== false && $expiry_date < strtotime( "+1 month" ) ) {
+				$message .= sprintf( __( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-nearing-limit-notice' ) );
+			}
+
+			if ( $expiry_date !== false && $expiry_date < strtotime( "+1 month" ) ) {
 				// Add extend notice if license is expiring in less than 1 month.
-				$days_left = round( ( $expiry_date - strtotime( "now" ) ) / 86400 );
-				$message .= sprintf( _n( '<a href="%s">Your license is expiring in %d day, would you like to extend it?</a>', '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a>', $days_left, $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+				$days_left = round( ( $expiry_date - time() ) / 86400 );
+				$message .= sprintf( _n( '<a href="%s">Your license is expiring in %d day, would you like to extend it?</a> ', '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $days_left, $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-expiring-notice' ), $days_left );
 			}
 
 			return $message;

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -683,7 +683,14 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 			// Make sure we limit the type of HTML elements to be displayed.
 			if ( ! empty( $message ) ) {
-				$message = strip_tags( $message, '<a>' );
+				$message = wp_kses( $message, array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+						'title'  => array()
+					),
+                    'br' => array(),
+				) );
 
 				// Make sure we are on a new line.
 				$message = '<br />' . $message;

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 				}
 
 				// Append custom HTML message to default message.
-				$message .= wpautop( $this->get_custom_message( $result ) );
+				$message .= $this->get_custom_message( $result );
 
 				$this->set_notice( $message, $success );
 

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -687,7 +687,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 				$message = strip_tags( $message, 'a,span,strong,b,em,i' );
 
 				// Make sure we are on a new line.
-				$message = PHP_EOL . $message;
+				$message = '<br />' . $message;
 			}
 
 			return $message;

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -643,8 +643,8 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
-         * Get the relevant locale
-         *
+		 * Get the relevant locale
+		 *
 		 * @return string
 		 */
 		protected function get_locale() {
@@ -656,8 +656,8 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
-         * Parse custom HTML message from response
-         *
+		 * Parse custom HTML message from response
+		 *
 		 * @param Object $result Result of the request.
 		 *
 		 * @return string
@@ -672,8 +672,8 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			}
 
 			// Fall back to default HTML Description if no locale has been provided.
-			if ( empty( $message ) && ! empty( $result->htmlDescription ) ) {
-				$message = $result->htmlDescription;
+			if ( empty( $message ) && ! empty( $result->html_description ) ) {
+				$message = $result->html_description;
 			}
 
 			// Make sure we limit the type of HTML elements to be displayed.

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -683,7 +683,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 			// Make sure we limit the type of HTML elements to be displayed.
 			if ( ! empty( $message ) ) {
-				$message = strip_tags( $message, 'a,span,strong,b,em,i' );
+				$message = strip_tags( $message, 'a' );
 
 				// Make sure we are on a new line.
 				$message = '<br />' . $message;

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -14,9 +14,6 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 	/**
 	 * Class Yoast_License_Manager
-	 *
-	 * @todo Maybe create a license class that contains key and option
-	 * @todo Not sure if Yoast_License_Manager is a good name for this class, it's more managing the product (plugin or theme)
 	 */
 	abstract class Yoast_License_Manager implements iYoast_License_Manager {
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,5 +12,6 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 } else {
 	require '../../../../tests/phpunit/includes/bootstrap.php';
 }
+
 // include unit test base class
 require_once dirname( __FILE__ ) . '/framework/class-yst-license-manager-unit-test-case.php';

--- a/tests/framework/class-yst-license-manager-unit-test-case.php
+++ b/tests/framework/class-yst-license-manager-unit-test-case.php
@@ -36,5 +36,4 @@ class Yst_License_Manager_UnitTestCase extends WP_UnitTestCase {
 		ob_clean();
 		$this->assertEquals( $output, $string );
 	}
-
 }

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -555,6 +555,23 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests if allowed HTML tags still remain after parsing
+	 *
+	 * @covers Yoast_License_Manager::get_custom_message()
+	 */
+	public function test_custom_message_allowed_html_tags_attributes() {
+		$message  = 'Normal HTML Message<br /> with a <a href="http://example.com" target="_blank" title="bla" style="invalid">link</a>.';
+		$expected = 'Normal HTML Message<br /> with a <a href="http://example.com" target="_blank" title="bla">link</a>.';
+
+		$object                   = new StdClass();
+		$object->html_description = $message;
+
+		$result = $this->class->get_custom_message( $object );
+
+		$this->assertEquals( $result, '<br />' . $expected );
+	}
+
+	/**
 	 * Tests if non-allowed tags are being removed from the message
 	 *
 	 * @covers Yoast_License_Manager::get_custom_message()

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -119,7 +119,11 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	/** @var Yoast_License_Manager_Double */
 	private $class;
 
+	/**
+	 * Set up before each test
+	 */
 	public function setUp() {
+		// Create a new double for every run.
 		$this->class = new Yoast_License_Manager_Double();
 	}
 
@@ -150,6 +154,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for successful unlimited license activation
+	 *
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_unlimited() {
@@ -167,6 +173,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for successful activation with remaining activations
+	 *
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license() {
@@ -184,6 +192,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for successful activation with upgrade message
+	 *
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license_upgrade() {
@@ -202,6 +212,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for successful activation which will expire soon
+	 *
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license_extend() {
@@ -221,6 +233,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for successful activation which will expire tomorrow
+	 *
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license_extend_tomorrow() {
@@ -240,6 +254,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for successful activation which expires soon and can be upgraded
+	 *
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license_upgrade_extend() {
@@ -262,6 +278,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 
 	/**
+	 * Tests message for unsuccessful activation without specific error code
+	 *
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message() {
@@ -276,6 +294,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for unsuccessful activation when activation limit is reached
+	 *
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message_no_activations_left() {
@@ -290,6 +310,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message for unsuccessful activation when license is expired
+	 *
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message_expired() {
@@ -304,9 +326,27 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests regular custom message
+	 *
 	 * @covers Yoast_License_Manager::get_custom_message()
 	 */
 	public function test_get_custom_message() {
+		$message = 'Normal HTML Message';
+
+		$object                   = new StdClass();
+		$object->html_description = $message;
+
+		$result = $this->class->get_custom_message( $object );
+
+		$this->assertEquals( $result, '<br />' . $message );
+	}
+
+	/**
+	 * Tests locale specific custom message
+	 *
+	 * @covers Yoast_License_Manager::get_custom_message()
+	 */
+	public function test_get_custom_message_locale() {
 		$message = 'locale message';
 
 		$locale = $this->class->get_locale();
@@ -320,16 +360,26 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests notice on licence API unsuccessful request
+	 *
 	 * @covers Yoast_License_Manager::activate_license()
 	 */
 	public function test_activate_license_failed_api_response() {
+		// API response will be `false`.
 		$this->class->set_license_api_response( 'activate', false );
 
-		$this->assertFalse( $this->class->activate_license() );
+		$activated = $this->class->activate_license();
+
+		// Activation will fail.
+		$this->assertFalse( $activated );
+
+		// No notice will be triggered.
 		$this->assertEquals( [], $this->class->__get_notices() );
 	}
 
 	/**
+	 * Tests notice on successful unlimited license activation
+	 *
 	 * @covers Yoast_License_Manager::activate_license()
 	 */
 	public function test_activate_license_success() {
@@ -352,6 +402,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests notice on successful unlimited license activation with custom message
+	 *
 	 * @covers Yoast_License_Manager::activate_license()
 	 */
 	public function test_activate_license_success_custom_message() {
@@ -375,17 +427,26 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests state on failed deactivation
+	 *
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_failed_response() {
+		// Current state is activated.
 		$this->class->set_license_status( 'activated' );
+
+		// API response will be `false`.
 		$this->class->set_license_api_response( 'deactivate', false );
 
-		$this->assertFalse( $this->class->deactivate_license() );
+		$deactivated = $this->class->deactivate_license();
+
+		$this->assertFalse( $deactivated );
 		$this->assertEquals( 'activated', $this->class->get_license_status() );
 	}
 
 	/**
+	 * Tests message on successful deactivation
+	 *
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_success() {
@@ -407,6 +468,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message on successful deactivation with custom message
+	 *
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_success_custom_message() {
@@ -429,6 +492,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message on unsuccessful deactivation
+	 *
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_failed() {
@@ -450,6 +515,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	}
 
 	/**
+	 * Tests message on unsuccessful deactivation with custom message
+	 *
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_failed_custom_message() {

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -25,26 +25,35 @@ class Yoast_License_Manager_Double extends Yoast_License_Manager {
 	}
 
 	public function specific_hooks() {
-		return $this->specific_hooks();
 	}
 
 	public function setup_auto_updater() {
-		return $this->setup_auto_updater();
 	}
 
-	/**
-	 * Wrapper for get_curl_version()
-	 *
-	 * @return mixed
-	 */
-	public function double_get_curl_version(){
-		return $this->get_curl_version();
+	public function get_curl_version() {
+		return parent::get_curl_version();
 	}
 
+	public function get_custom_message( $result ) {
+		return parent::get_custom_message( $result );
+	}
+
+	public function get_locale() {
+		return parent::get_locale();
+	}
+
+	public function get_successful_activation_message( $result ) {
+		return parent::get_successful_activation_message( $result );
+	}
+
+	public function get_unsuccessful_activation_message( $result ) {
+		return parent::get_unsuccessful_activation_message( $result );
+	}
 }
 
 class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
+	/** @var Yoast_License_Manager_Double */
 	private $class;
 
 	public function setUp() {
@@ -54,9 +63,9 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	/**
 	 * Make sure the API url is correct in the product
 	 *
-	 * @covers Yoast_License_Manager::get_api_url()
+	 * @covers Yoast_Product::get_api_url()
 	 */
-	public function test_get_api_url(){
+	public function test_get_api_url() {
 		$this->assertEquals( $this->class->product->get_api_url(), get_site_url() );
 	}
 
@@ -65,17 +74,45 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 *
 	 * @covers Yoast_License_Manager::get_curl_version()
 	 */
-	public function test_get_curl_version_WITH_curl_installed_on_test_server(){
-		$curl_result = $this->class->double_get_curl_version();
+	public function test_get_curl_version_WITH_curl_installed_on_test_server() {
+		$curl_result = $this->class->get_curl_version();
 
-		if( function_exists('curl_version') ){
+		if ( function_exists( 'curl_version' ) ) {
 			$curl_version = curl_version();
 
 			$this->assertEquals( $curl_result, $curl_version['version'] );
-		}
-		else{
+		} else {
 			$this->assertFalse( $curl_result );
 		}
 	}
 
+	/**
+	 * @covers Yoast_License_Manager::get_successful_activation_message()
+	 */
+	public function test_get_successful_activation_message() {
+
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
+	 */
+	public function test_get_unsuccessful_activation_message() {
+
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_custom_message()
+	 */
+	public function test_get_custom_message() {
+		$message = 'locale message';
+
+		$locale = $this->class->get_locale();
+
+		$object = new StdClass();
+		$object->{'html_description_'.$locale} = $message;
+
+		$result = $this->class->get_custom_message( $object );
+
+		$this->assertEquals( $result, PHP_EOL . $message );
+	}
 }

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -537,4 +537,37 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 			)
 		), $this->class->__get_notices() );
 	}
+
+	/**
+	 * Tests if allowed HTML tags still remain after parsing
+	 *
+	 * @covers Yoast_License_Manager::get_custom_message()
+	 */
+	public function test_custom_message_allowed_html_tags() {
+		$message = 'Normal HTML Message with a <a href="http://example.com">link</a>.';
+
+		$object                   = new StdClass();
+		$object->html_description = $message;
+
+		$result = $this->class->get_custom_message( $object );
+
+		$this->assertEquals( $result, '<br />' . $message );
+	}
+
+	/**
+	 * Tests if non-allowed tags are being removed from the message
+	 *
+	 * @covers Yoast_License_Manager::get_custom_message()
+	 */
+	public function test_custom_message_disallowed_html_tags() {
+		$message  = 'Normal HTML Message with a <strong>link</strong>.';
+		$expected = 'Normal HTML Message with a link.';
+
+		$object                   = new StdClass();
+		$object->html_description = $message;
+
+		$result = $this->class->get_custom_message( $object );
+
+		$this->assertEquals( $result, '<br />' . $expected );
+	}
 }

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -62,8 +62,8 @@ class Yoast_License_Manager_Double extends Yoast_License_Manager {
 	/**
 	 * Expose protected function.
 	 */
-	public function get_locale() {
-		return parent::get_locale();
+	public function get_user_locale() {
+		return parent::get_user_locale();
 	}
 
 	/**
@@ -160,14 +160,15 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 */
 	public function test_get_successful_activation_message_unlimited() {
 
-		$object                = new StdClass();
-		$object->license_limit = 0;
-		$object->expiry_date   = false;
+		$api_response = (object) array(
+			'license_limit' => 0,
+			'expiry_date'   => false
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
 
-		$result = $this->class->get_successful_activation_message( $object );
+		$result = $this->class->get_successful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -178,15 +179,16 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license() {
-		$object                = new StdClass();
-		$object->site_count    = 2;
-		$object->license_limit = 8;
-		$object->expires       = false;
+		$api_response = (object) array(
+			'license_limit' => 8,
+			'site_count'    => 2,
+			'expires'       => false
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
-		$message .= sprintf( 'You have used %d/%d activations. ', $object->site_count, $object->license_limit );
+		$message = 'Your test-product license has been activated. ';
+		$message .= 'You have used 2/8 activations. ';
 
-		$result = $this->class->get_successful_activation_message( $object );
+		$result = $this->class->get_successful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -197,16 +199,17 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
 	public function test_get_successful_activation_message_limited_license_upgrade() {
-		$object                = new StdClass();
-		$object->site_count    = 2;
-		$object->license_limit = 3;
-		$object->expires       = false;
+		$api_response = (object) array(
+			'site_count'    => 2,
+			'license_limit' => 3,
+			'expires'       => false
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
-		$message .= sprintf( 'You have used %d/%d activations. ', $object->site_count, $object->license_limit );
+		$message = 'Your test-product license has been activated. ';
+		$message .= 'You have used 2/3 activations. ';
 		$message .= sprintf( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->class->product->get_extension_url( 'license-nearing-limit-notice' ) );
 
-		$result = $this->class->get_successful_activation_message( $object );
+		$result = $this->class->get_successful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -219,15 +222,16 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_get_successful_activation_message_limited_license_extend() {
 		$days_left = 5;
 
-		$object                = new StdClass();
-		$object->license_limit = 0;
-		$object->expires       = date( DATE_RSS, time() + ( $days_left * 86400 ) );
+		$api_response = (object) array(
+			'license_limit' => 0,
+			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) )
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
-		$message .= sprintf( '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+		$message .= sprintf( '<a href="%s">Your license is expiring in 5 days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ) );
 
-		$result = $this->class->get_successful_activation_message( $object );
+		$result = $this->class->get_successful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -240,15 +244,16 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_get_successful_activation_message_limited_license_extend_tomorrow() {
 		$days_left = 1;
 
-		$object                = new StdClass();
-		$object->license_limit = 0;
-		$object->expires       = date( DATE_RSS, time() + ( $days_left * 86400 ) );
+		$api_response = (object) array(
+			'license_limit' => 0,
+			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) )
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
-		$message .= sprintf( '<a href="%s">Your license is expiring in %d day, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+		$message .= sprintf( '<a href="%s">Your license is expiring in 1 day, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ) );
 
-		$result = $this->class->get_successful_activation_message( $object );
+		$result = $this->class->get_successful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -261,17 +266,18 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_get_successful_activation_message_limited_license_upgrade_extend() {
 		$days_left = 5;
 
-		$object                = new StdClass();
-		$object->site_count    = 2;
-		$object->license_limit = 3;
-		$object->expires       = date( DATE_RSS, time() + ( $days_left * 86400 ) );
+		$api_response = (object) array(
+			'site_count'    => 2,
+			'license_limit' => 3,
+			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) )
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
-		$message .= sprintf( 'You have used %d/%d activations. ', $object->site_count, $object->license_limit );
+		$message = 'Your test-product license has been activated. ';
+		$message .= 'You have used 2/3 activations. ';
 		$message .= sprintf( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->class->product->get_extension_url( 'license-nearing-limit-notice' ) );
-		$message .= sprintf( '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+		$message .= sprintf( '<a href="%s">Your license is expiring in 5 days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ) );
 
-		$result = $this->class->get_successful_activation_message( $object );
+		$result = $this->class->get_successful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -283,12 +289,13 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message() {
-		$object        = new StdClass();
-		$object->error = '';
+		$api_response = (object) array(
+			'error' => ''
+		);
 
 		$message = 'Failed to activate your license, your license key seems to be invalid.';
 
-		$result = $this->class->get_unsuccessful_activation_message( $object );
+		$result = $this->class->get_unsuccessful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -299,12 +306,13 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message_no_activations_left() {
-		$object        = new StdClass();
-		$object->error = 'no_activations_left';
+		$api_response = (object) array(
+			'error' => 'no_activations_left'
+		);
 
 		$message = sprintf( 'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.', $this->class->product->get_extension_url( 'license-at-limit-notice' ) );
 
-		$result = $this->class->get_unsuccessful_activation_message( $object );
+		$result = $this->class->get_unsuccessful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -315,12 +323,13 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message_expired() {
-		$object        = new StdClass();
-		$object->error = 'expired';
+		$api_response = (object) array(
+			'error' => 'expired'
+		);
 
 		$message = sprintf( 'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.', $this->class->product->get_extension_url( 'license-expired-notice' ) );
 
-		$result = $this->class->get_unsuccessful_activation_message( $object );
+		$result = $this->class->get_unsuccessful_activation_message( $api_response );
 
 		$this->assertEquals( $result, $message );
 	}
@@ -333,10 +342,11 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_get_custom_message() {
 		$message = 'Normal HTML Message';
 
-		$object                   = new StdClass();
-		$object->html_description = $message;
+		$api_response = (object) array(
+			'custom_message' => $message,
+		);
 
-		$result = $this->class->get_custom_message( $object );
+		$result = $this->class->get_custom_message( $api_response );
 
 		$this->assertEquals( $result, '<br />' . $message );
 	}
@@ -349,12 +359,13 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_get_custom_message_locale() {
 		$message = 'locale message';
 
-		$locale = $this->class->get_locale();
+		$locale = $this->class->get_user_locale();
 
-		$object                                  = new StdClass();
-		$object->{'html_description_' . $locale} = $message;
+		$api_response = (object) array(
+			'custom_message_' . $locale => $message
+		);
 
-		$result = $this->class->get_custom_message( $object );
+		$result = $this->class->get_custom_message( $api_response );
 
 		$this->assertEquals( $result, '<br />' . $message );
 	}
@@ -374,7 +385,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertFalse( $activated );
 
 		// No notice will be triggered.
-		$this->assertEquals( [], $this->class->__get_notices() );
+		$this->assertEquals( array(), $this->class->__get_notices() );
 	}
 
 	/**
@@ -383,14 +394,15 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::activate_license()
 	 */
 	public function test_activate_license_success() {
-		$object                = new StdClass();
-		$object->license       = 'valid';
-		$object->license_limit = 0;
+		$api_response = (object) array(
+			'license'       => 'valid',
+			'license_limit' => 0,
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
 
-		$this->class->set_license_api_response( 'activate', $object );
+		$this->class->set_license_api_response( 'activate', $api_response );
 		$this->class->activate_license();
 
 		$this->assertEquals( array(
@@ -407,20 +419,22 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::activate_license()
 	 */
 	public function test_activate_license_success_custom_message() {
-		$object                   = new StdClass();
-		$object->license          = 'valid';
-		$object->license_limit    = 0;
-		$object->html_description = 'This is an HTML description.';
+		$api_response = (object) array(
+			'license'        => 'valid',
+			'license_limit'  => 0,
+			'custom_message' => 'This is an HTML description.'
+		);
 
-		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+
+		$message = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
 
-		$this->class->set_license_api_response( 'activate', $object );
+		$this->class->set_license_api_response( 'activate', $api_response );
 		$this->class->activate_license();
 
 		$this->assertEquals( array(
 			array(
-				'message' => $message . '<br />' . $object->html_description,
+				'message' => $message . '<br />' . $api_response->custom_message,
 				'success' => true
 			)
 		), $this->class->__get_notices() );
@@ -450,13 +464,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_success() {
-		$object          = new StdClass();
-		$object->license = 'deactivated';
+		$api_response = (object) array(
+			'license' => 'deactivated'
+		);
 
-		$message = sprintf( 'Your %s license has been deactivated.', $this->class->product->get_item_name() );
+		$message = 'Your test-product license has been deactivated.';
 
 		$this->class->set_license_status( 'activated' );
-		$this->class->set_license_api_response( 'deactivate', $object );
+		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertTrue( $this->class->deactivate_license() );
 		$this->assertEquals( array(
@@ -473,19 +488,20 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_success_custom_message() {
-		$object                   = new StdClass();
-		$object->license          = 'deactivated';
-		$object->html_description = 'This is an HTML description.';
+		$api_response = (object) array(
+			'license'        => 'deactivated',
+			'custom_message' => 'This is an HTML description.'
+		);
 
-		$message = sprintf( 'Your %s license has been deactivated.', $this->class->product->get_item_name() );
+		$message = 'Your test-product license has been deactivated.';
 
 		$this->class->set_license_status( 'activated' );
-		$this->class->set_license_api_response( 'deactivate', $object );
+		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertTrue( $this->class->deactivate_license() );
 		$this->assertEquals( array(
 			array(
-				'message' => $message . '<br />' . $object->html_description,
+				'message' => $message . '<br />' . $api_response->custom_message,
 				'success' => true
 			)
 		), $this->class->__get_notices() );
@@ -497,13 +513,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_failed() {
-		$object          = new StdClass();
-		$object->license = 'activated'; // Expected to be deactivated.
+		$api_response = (object) array(
+			'license' => 'activated' // Expected to be deactivated.
+		);
 
-		$message = sprintf( 'Failed to deactivate your %s license.', $this->class->product->get_item_name() );
+		$message = 'Failed to deactivate your test-product license.';
 
 		$this->class->set_license_status( 'activated' );
-		$this->class->set_license_api_response( 'deactivate', $object );
+		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertFalse( $this->class->deactivate_license() );
 		$this->assertEquals( array(
@@ -520,19 +537,20 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 * @covers Yoast_License_Manager::deactivate_license()
 	 */
 	public function test_deactivate_license_failed_custom_message() {
-		$object                   = new StdClass();
-		$object->license          = 'activated'; // Expected to be deactivated.
-		$object->html_description = 'This is an HTML description.';
+		$api_response = (object) array(
+			'license'        => 'activated', // Expected to be deactivated.
+			'custom_message' => 'This is an HTML description.'
+		);
 
-		$message = sprintf( 'Failed to deactivate your %s license.', $this->class->product->get_item_name() );
+		$message = 'Failed to deactivate your test-product license.';
 
 		$this->class->set_license_status( 'activated' );
-		$this->class->set_license_api_response( 'deactivate', $object );
+		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertFalse( $this->class->deactivate_license() );
 		$this->assertEquals( array(
 			array(
-				'message' => $message . '<br />' . $object->html_description,
+				'message' => $message . '<br />' . $api_response->custom_message,
 				'success' => false
 			)
 		), $this->class->__get_notices() );
@@ -546,10 +564,11 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_custom_message_allowed_html_tags() {
 		$message = 'Normal HTML Message with a <a href="http://example.com">link</a>.';
 
-		$object                   = new StdClass();
-		$object->html_description = $message;
+		$api_response = (object) array(
+			'custom_message' => $message
+		);
 
-		$result = $this->class->get_custom_message( $object );
+		$result = $this->class->get_custom_message( $api_response );
 
 		$this->assertEquals( $result, '<br />' . $message );
 	}
@@ -563,10 +582,11 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$message  = 'Normal HTML Message<br /> with a <a href="http://example.com" target="_blank" title="bla" style="invalid">link</a>.';
 		$expected = 'Normal HTML Message<br /> with a <a href="http://example.com" target="_blank" title="bla">link</a>.';
 
-		$object                   = new StdClass();
-		$object->html_description = $message;
+		$api_response = (object) array(
+			'custom_message' => $message
+		);
 
-		$result = $this->class->get_custom_message( $object );
+		$result = $this->class->get_custom_message( $api_response );
 
 		$this->assertEquals( $result, '<br />' . $expected );
 	}
@@ -580,10 +600,11 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$message  = 'Normal HTML Message with a <strong>link</strong>.';
 		$expected = 'Normal HTML Message with a link.';
 
-		$object                   = new StdClass();
-		$object->html_description = $message;
+		$api_response = (object) array(
+			'custom_message' => $message
+		);
 
-		$result = $this->class->get_custom_message( $object );
+		$result = $this->class->get_custom_message( $api_response );
 
 		$this->assertEquals( $result, '<br />' . $expected );
 	}

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -1,8 +1,11 @@
 <?php
 
-include( dirname( __FILE__ ) . '../../class-product.php' );
-include( dirname( __FILE__ ) . '../../class-license-manager.php' );
+include dirname( __FILE__ ) . '../../class-product.php';
+include dirname( __FILE__ ) . '../../class-license-manager.php';
 
+/**
+ * Class Yoast_Product_Double
+ */
 class Yoast_Product_Double extends Yoast_Product {
 
 	/**
@@ -14,9 +17,15 @@ class Yoast_Product_Double extends Yoast_Product {
 
 }
 
+/**
+ * Class Yoast_License_Manager_Double
+ */
 class Yoast_License_Manager_Double extends Yoast_License_Manager {
 
 	public $product;
+
+	protected $__notices = array();
+	protected $license_api_response = array();
 
 	public function __construct() {
 		$this->product = new Yoast_Product_Double();
@@ -24,30 +33,84 @@ class Yoast_License_Manager_Double extends Yoast_License_Manager {
 		parent::__construct( $this->product );
 	}
 
+	/**
+	 * Needs to be defined.
+	 */
 	public function specific_hooks() {
 	}
 
+	/**
+	 * Needs to be defined.
+	 */
 	public function setup_auto_updater() {
 	}
 
+	/**
+	 * Expose protected function.
+	 */
 	public function get_curl_version() {
 		return parent::get_curl_version();
 	}
 
+	/**
+	 * Expose protected function.
+	 */
 	public function get_custom_message( $result ) {
 		return parent::get_custom_message( $result );
 	}
 
+	/**
+	 * Expose protected function.
+	 */
 	public function get_locale() {
 		return parent::get_locale();
 	}
 
+	/**
+	 * Expose protected function.
+	 */
 	public function get_successful_activation_message( $result ) {
 		return parent::get_successful_activation_message( $result );
 	}
 
+	/**
+	 * Expose protected function.
+	 */
 	public function get_unsuccessful_activation_message( $result ) {
 		return parent::get_unsuccessful_activation_message( $result );
+	}
+
+	/**
+	 * Override functionality to catch notices
+	 * @todo mock this instead
+	 */
+	protected function set_notice( $message, $success = true ) {
+		$this->__notices[] = array( 'message' => $message, 'success' => $success );
+	}
+
+	/**
+	 * Get caught notices
+	 */
+	public function __get_notices() {
+		return $this->__notices;
+	}
+
+	/**
+	 * Override functionality to return custom response
+	 * @todo mock this instead
+	 */
+	public function call_license_api( $action ) {
+		return $this->license_api_response[ $action ];
+	}
+
+	/**
+	 * Set a certain response for a license_api call
+	 *
+	 * @param string $action   Action to respond to.
+	 * @param mixed  $response Response to give back.
+	 */
+	public function set_license_api_response( $action, $response ) {
+		$this->license_api_response[ $action ] = $response;
 	}
 }
 
@@ -89,15 +152,155 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	/**
 	 * @covers Yoast_License_Manager::get_successful_activation_message()
 	 */
-	public function test_get_successful_activation_message() {
+	public function test_get_successful_activation_message_unlimited() {
 
+		$object                = new StdClass();
+		$object->license_limit = 0;
+		$object->expiry_date   = false;
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= 'You have an unlimited license. ';
+
+		$result = $this->class->get_successful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
 	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_successful_activation_message()
+	 */
+	public function test_get_successful_activation_message_limited_license() {
+		$object                = new StdClass();
+		$object->site_count    = 2;
+		$object->license_limit = 8;
+		$object->expires       = false;
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= sprintf( 'You have used %d/%d activations. ', $object->site_count, $object->license_limit );
+
+		$result = $this->class->get_successful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_successful_activation_message()
+	 */
+	public function test_get_successful_activation_message_limited_license_upgrade() {
+		$object                = new StdClass();
+		$object->site_count    = 2;
+		$object->license_limit = 3;
+		$object->expires       = false;
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= sprintf( 'You have used %d/%d activations. ', $object->site_count, $object->license_limit );
+		$message .= sprintf( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->class->product->get_extension_url( 'license-nearing-limit-notice' ) );
+
+		$result = $this->class->get_successful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_successful_activation_message()
+	 */
+	public function test_get_successful_activation_message_limited_license_extend() {
+		$days_left = 5;
+
+		$object                = new StdClass();
+		$object->license_limit = 0;
+		$object->expires       = date( DATE_RSS, time() + ( $days_left * 86400 ) );
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= 'You have an unlimited license. ';
+		$message .= sprintf( '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+
+		$result = $this->class->get_successful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_successful_activation_message()
+	 */
+	public function test_get_successful_activation_message_limited_license_extend_tomorrow() {
+		$days_left = 1;
+
+		$object                = new StdClass();
+		$object->license_limit = 0;
+		$object->expires       = date( DATE_RSS, time() + ( $days_left * 86400 ) );
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= 'You have an unlimited license. ';
+		$message .= sprintf( '<a href="%s">Your license is expiring in %d day, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+
+		$result = $this->class->get_successful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_successful_activation_message()
+	 */
+	public function test_get_successful_activation_message_limited_license_upgrade_extend() {
+		$days_left = 5;
+
+		$object                = new StdClass();
+		$object->site_count    = 2;
+		$object->license_limit = 3;
+		$object->expires       = date( DATE_RSS, time() + ( $days_left * 86400 ) );
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= sprintf( 'You have used %d/%d activations. ', $object->site_count, $object->license_limit );
+		$message .= sprintf( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->class->product->get_extension_url( 'license-nearing-limit-notice' ) );
+		$message .= sprintf( '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+
+		$result = $this->class->get_successful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
 
 	/**
 	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
 	 */
 	public function test_get_unsuccessful_activation_message() {
+		$object        = new StdClass();
+		$object->error = '';
 
+		$message = 'Failed to activate your license, your license key seems to be invalid.';
+
+		$result = $this->class->get_unsuccessful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
+	 */
+	public function test_get_unsuccessful_activation_message_no_activations_left() {
+		$object        = new StdClass();
+		$object->error = 'no_activations_left';
+
+		$message = sprintf( 'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.', $this->class->product->get_extension_url( 'license-at-limit-notice' ) );
+
+		$result = $this->class->get_unsuccessful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::get_unsuccessful_activation_message()
+	 */
+	public function test_get_unsuccessful_activation_message_expired() {
+		$object        = new StdClass();
+		$object->error = 'expired';
+
+		$message = sprintf( 'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.', $this->class->product->get_extension_url( 'license-expired-notice' ) );
+
+		$result = $this->class->get_unsuccessful_activation_message( $object );
+
+		$this->assertEquals( $result, $message );
 	}
 
 	/**
@@ -108,11 +311,163 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$locale = $this->class->get_locale();
 
-		$object = new StdClass();
-		$object->{'html_description_'.$locale} = $message;
+		$object                                  = new StdClass();
+		$object->{'html_description_' . $locale} = $message;
 
 		$result = $this->class->get_custom_message( $object );
 
-		$this->assertEquals( $result, PHP_EOL . $message );
+		$this->assertEquals( $result, '<br />' . $message );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::activate_license()
+	 */
+	public function test_activate_license_failed_api_response() {
+		$this->class->set_license_api_response( 'activate', false );
+
+		$this->assertFalse( $this->class->activate_license() );
+		$this->assertEquals( [], $this->class->__get_notices() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::activate_license()
+	 */
+	public function test_activate_license_success() {
+		$object                = new StdClass();
+		$object->license       = 'valid';
+		$object->license_limit = 0;
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= 'You have an unlimited license. ';
+
+		$this->class->set_license_api_response( 'activate', $object );
+		$this->class->activate_license();
+
+		$this->assertEquals( array(
+			array(
+				'message' => $message,
+				'success' => true
+			)
+		), $this->class->__get_notices() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::activate_license()
+	 */
+	public function test_activate_license_success_custom_message() {
+		$object                   = new StdClass();
+		$object->license          = 'valid';
+		$object->license_limit    = 0;
+		$object->html_description = 'This is an HTML description.';
+
+		$message = sprintf( 'Your %s license has been activated. ', $this->class->product->get_item_name() );
+		$message .= 'You have an unlimited license. ';
+
+		$this->class->set_license_api_response( 'activate', $object );
+		$this->class->activate_license();
+
+		$this->assertEquals( array(
+			array(
+				'message' => $message . '<br />' . $object->html_description,
+				'success' => true
+			)
+		), $this->class->__get_notices() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::deactivate_license()
+	 */
+	public function test_deactivate_license_failed_response() {
+		$this->class->set_license_status( 'activated' );
+		$this->class->set_license_api_response( 'deactivate', false );
+
+		$this->assertFalse( $this->class->deactivate_license() );
+		$this->assertEquals( 'activated', $this->class->get_license_status() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::deactivate_license()
+	 */
+	public function test_deactivate_license_success() {
+		$object          = new StdClass();
+		$object->license = 'deactivated';
+
+		$message = sprintf( 'Your %s license has been deactivated.', $this->class->product->get_item_name() );
+
+		$this->class->set_license_status( 'activated' );
+		$this->class->set_license_api_response( 'deactivate', $object );
+
+		$this->assertTrue( $this->class->deactivate_license() );
+		$this->assertEquals( array(
+			array(
+				'message' => $message,
+				'success' => true
+			)
+		), $this->class->__get_notices() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::deactivate_license()
+	 */
+	public function test_deactivate_license_success_custom_message() {
+		$object                   = new StdClass();
+		$object->license          = 'deactivated';
+		$object->html_description = 'This is an HTML description.';
+
+		$message = sprintf( 'Your %s license has been deactivated.', $this->class->product->get_item_name() );
+
+		$this->class->set_license_status( 'activated' );
+		$this->class->set_license_api_response( 'deactivate', $object );
+
+		$this->assertTrue( $this->class->deactivate_license() );
+		$this->assertEquals( array(
+			array(
+				'message' => $message . '<br />' . $object->html_description,
+				'success' => true
+			)
+		), $this->class->__get_notices() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::deactivate_license()
+	 */
+	public function test_deactivate_license_failed() {
+		$object          = new StdClass();
+		$object->license = 'activated'; // Expected to be deactivated.
+
+		$message = sprintf( 'Failed to deactivate your %s license.', $this->class->product->get_item_name() );
+
+		$this->class->set_license_status( 'activated' );
+		$this->class->set_license_api_response( 'deactivate', $object );
+
+		$this->assertFalse( $this->class->deactivate_license() );
+		$this->assertEquals( array(
+			array(
+				'message' => $message,
+				'success' => false
+			)
+		), $this->class->__get_notices() );
+	}
+
+	/**
+	 * @covers Yoast_License_Manager::deactivate_license()
+	 */
+	public function test_deactivate_license_failed_custom_message() {
+		$object                   = new StdClass();
+		$object->license          = 'activated'; // Expected to be deactivated.
+		$object->html_description = 'This is an HTML description.';
+
+		$message = sprintf( 'Failed to deactivate your %s license.', $this->class->product->get_item_name() );
+
+		$this->class->set_license_status( 'activated' );
+		$this->class->set_license_api_response( 'deactivate', $object );
+
+		$this->assertFalse( $this->class->deactivate_license() );
+		$this->assertEquals( array(
+			array(
+				'message' => $message . '<br />' . $object->html_description,
+				'success' => false
+			)
+		), $this->class->__get_notices() );
 	}
 }


### PR DESCRIPTION
Testing instructions:

The "easiest" way to test this is to have a local EDD Software Licensing plugin active on specific endpoint.

To make the License Manager use the specific installation; modify the constant in the `WPSEO_Premium` class: `const EDD_STORE_URL = 'http://my.yoast.dev';`

In that installation add the following filter:

```php
add_filter( 'edd_remote_license_activation_response', function( $result ) {

    $result['custom_message_nl_NL'] = 'Dit is een <a href="https://my.yoast.com/activate-license/" target="_blank">eigen melding</a>!';
    $result['custom_message'] = 'This is a <a href="https://my.yoast.com/activate-license/" target="_blank">custom message</a>!';
    return $result;

}, 10, 1 );
```

Which will add a custom message to any activation response (successful or non-successful).
When the user (or site) language has been set to "Nederlands" it will show the dutch version of the custom message instead of the english one.

Fixes https://github.com/Yoast/License-Manager/issues/105