### PR TITLE
Provides custom license page capability control

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -104,7 +104,13 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		 */
 		public function display_admin_notices() {
 
-			if ( ! current_user_can( 'manage_options' ) ) {
+			$capability = 'manage_options';
+			// Get custom capability from product if method is implemented.
+			if ( method_exists( $this->product, 'get_license_page_capability' ) ) {
+				$capability = $this->product->get_license_page_capability();
+			}
+
+			if ( ! current_user_can( $capability ) ) {
 				return;
 			}
 

--- a/class-theme-license-manager.php
+++ b/class-theme-license-manager.php
@@ -11,7 +11,7 @@ if ( class_exists( 'Yoast_License_Manager' ) && ! class_exists( "Yoast_Theme_Lic
 			if ( $this->license_is_valid() ) {
 				// setup auto updater
 				require_once dirname( __FILE__ ) . '/class-update-manager.php';
-				require_once dirname( __FILE__ ) . '/class-theme-update-manager.php'; // @TODO: Autoload?
+				require_once dirname( __FILE__ ) . '/class-theme-update-manager.php';
 				new Yoast_Theme_Update_Manager( $this->product, $this );
 			}
 		}
@@ -31,7 +31,12 @@ if ( class_exists( 'Yoast_License_Manager' ) && ! class_exists( "Yoast_Theme_Lic
 		 * Add license page and add it to Themes menu
 		 */
 		public function add_license_menu() {
-			add_theme_page( sprintf( __( '%s License', $this->product->get_text_domain() ), $this->product->get_item_name() ), __( 'Theme License', $this->product->get_text_domain() ), 'manage_options', 'theme-license', array( $this, 'show_license_page' ) );
+			$capability = 'manage_options';
+			if ( method_exists( $this->product, 'get_license_page_capability' ) ) {
+				$capability = $this->product->get_license_page_capability();
+			}
+
+			add_theme_page( sprintf( __( '%s License', $this->product->get_text_domain() ), $this->product->get_item_name() ), __( 'Theme License', $this->product->get_text_domain() ), $capability, 'theme-license', array( $this, 'show_license_page' ) );
 		}
 
 		/**


### PR DESCRIPTION
Relevant technical considerations:
I have not implemented a filter because the naming would be very difficult, as this code might not only be used as the abstract Yoast_License_Manager. Because the code has to be PHP 5.2 compatibly, we cannot use Late Static Binding, so the final name of the class is unknown at this part of the code.

Testing for a method before calling it is a safe way to provide additional functionality without breaking any backwards compatibility.

`manage_options` will remain the default when no function is implemented, so the functionality will remain the same.

Fixes https://github.com/Yoast/License-Manager/issues/103