### PR TITLE
Introduces new hook to expose raw response data

### DIFF
--- a/class-api-request.php
+++ b/class-api-request.php
@@ -69,7 +69,7 @@ if ( ! class_exists( "Yoast_API_Request", false ) ) {
 			$response = wp_remote_request( $this->url, $this->args );
 
 			/**
-			 * Hook: 'license_manager-server_response' - Exposes the raw response from the license server.
+			 * Hook: 'license_manager_server_response' - Exposes the raw response from the license server.
 			 *
 			 * @response  array|WP_Error The raw response data.
 			 * @url       string         The requested license server URL.

--- a/class-api-request.php
+++ b/class-api-request.php
@@ -68,6 +68,15 @@ if ( ! class_exists( "Yoast_API_Request", false ) ) {
 			// fire request to shop
 			$response = wp_remote_request( $this->url, $this->args );
 
+			/**
+			 * Hook: 'license_manager-server_response' - Exposes the raw response from the license server.
+			 *
+			 * @response  array|WP_Error The raw response data.
+			 * @url       string         The requested license server URL.
+			 * @arguments array          The requested license request arguments.
+			 */
+			do_action( 'license_manager_server_response', $response, $this->url, $this->args );
+
 			// validate raw response
 			if( $this->validate_raw_response( $response ) === false ) {
 				return false;


### PR DESCRIPTION
The `$this->url` is based on the Product License URL, which is set in the implementation environment. Based on that URL there should be enough context to only listen to related requests for the implemented products.

The action name should be specific enough; please take a moment to analyze it.

Fixes: https://github.com/Yoast/License-Manager/issues/112