### PR TITLE
Add wrapper for getting the home url

### DIFF
--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -111,7 +111,7 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 				'item_name'    => $this->product->get_item_name(),
 				'wp_version'   => $wp_version,
 				'item_version' => $this->product->get_version(),
-				'url'          => home_url(),
+				'url'          => $this->get_home_url(),
 				'slug'         => $this->product->get_slug(),
 			);
 
@@ -217,6 +217,35 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 			}
 
 			return false;
+		}
+
+		/**
+		 * Returns the real home url without any WPML language additions.
+		 *
+		 * @return string The home url.
+		 */
+		private function get_home_url() {
+
+			add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
+
+			$home_url = home_url();
+
+			remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
+
+			return $home_url;
+		}
+
+		/**
+		 * This method is trigger by filter wpml_get_home_url and returns the $url this is the url before the filter
+		 * has been executed and can be considered as the one that isn't altered by WPML.
+		 *
+		 * @param string $home_url The url altered by WPML. Unused.
+		 * @param string $url      The url that isn't altered by WPML.
+		 *
+		 * @return string The original url.
+		 */
+		public function wpml_get_home_url( $home_url, $url ) {
+			return $url;
 		}
 
 	}

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -236,6 +236,8 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 		}
 
 		/**
+		 * Returns the original URL instead of the language-enriched URL.
+		 *
 		 * This method is trigger by filter wpml_get_home_url and returns the $url this is the url before the filter
 		 * has been executed and can be considered as the one that isn't altered by WPML.
 		 *


### PR DESCRIPTION
WPML is altering the home url by appending the language to it. This pull should solve that.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/945

This pull can be tested by having WPML installed. 
* Add this branch as a dev dependency in WordPress SEO Premium in composer. Something like: `dev-stories/handle-wpml-home-url`.
* Do a `composer install`
* Have a way to catch the request. Or try to echo the get_home_url() to see it is altered correctly. For example in the file `class-update-manager.php` do a `print_r` on line 117 where to print the value of `api_params`
* Activate a premium plugin or extension. You probably need a license key for it.
* Go the the updates page and force the check by pressing: check again.