### PR TITLE
Add get_home_url function

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -237,6 +237,39 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
+		 * Returns the correct url.
+		 */
+		public function get_home_url() {
+		    if ( ! is_multisite() ) {
+                // Add a new filter to undo WPML's changing of home url.
+			    add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
+
+			    $home_url = home_url();
+
+			    remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
+
+			    return $home_url;
+            }
+            // WPML does not change the network home url so we can return it without modification.
+		    return network_home_url();
+        }
+
+		/**
+		 * Returns the original URL instead of the language-enriched URL.
+		 *
+		 * This method is trigger by filter wpml_get_home_url and returns the $url this is the url before the filter
+		 * has been executed and can be considered as the one that isn't altered by WPML.
+		 *
+		 * @param string $home_url The url altered by WPML. Unused.
+		 * @param string $url      The url that isn't altered by WPML.
+		 *
+		 * @return string The original url.
+		 */
+		public function wpml_get_home_url( $home_url, $url ) {
+			return $url;
+		}
+
+		/**
 		 * @param string $action activate|deactivate
 		 *
 		 * @return mixed
@@ -253,7 +286,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 				'edd_action' => $action . '_license',
 				'license'    => $this->get_license_key(),
 				'item_name'  => urlencode( trim( $this->product->get_item_name() ) ),
-				'url'        => get_option( 'home' )
+				'url'        => $this->get_home_url()
 				// grab the URL straight from the option to prevent filters from breaking it.
 			);
 

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -237,21 +237,33 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		}
 
 		/**
-		 * Returns the correct url.
+		 * Returns the home url with the following modifications:
+		 *
+		 * In case of a multisite setup we return the network_home_url.
+		 * In case of no multisite setup we return the home_url while overriding the WPML filter.
+		 */
+		public function get_url() {
+			if ( is_multisite() ) {
+				// WPML does not change the network home url so we can return it without modification.
+				return network_home_url();
+			}
+			return $this->get_home_url();
+		}
+
+		/**
+		 * Returns the real home url without any WPML language additions.
+		 *
+		 * @return string The home url.
 		 */
 		public function get_home_url() {
-			if ( ! is_multisite() ) {
-				// Add a new filter to undo WPML's changing of home url.
-				add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
+			// Add a new filter to undo WPML's changing of home url.
+			add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
 
-				$home_url = home_url();
+			$home_url = home_url();
 
-				remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
+			remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
 
-				return $home_url;
-			}
-			// WPML does not change the network home url so we can return it without modification.
-			return network_home_url();
+			return $home_url;
 		}
 
 		/**
@@ -286,7 +298,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 				'edd_action' => $action . '_license',
 				'license'    => $this->get_license_key(),
 				'item_name'  => urlencode( trim( $this->product->get_item_name() ) ),
-				'url'        => $this->get_home_url()
+				'url'        => $this->get_url()
 				// grab the URL straight from the option to prevent filters from breaking it.
 			);
 

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -246,8 +246,15 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 			// Add a new filter to undo WPML's changing of home url.
 			add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
 
-			// Network home url will return home url for non-network installs.
-			$url = network_home_url();
+			// If the plugin is network activated, use the network home URL.
+			if ( $this->is_network_activated ) {
+				$url = network_home_url();
+			}
+
+			// Otherwise use the home URL for this specific site.
+			if ( ! $this->is_network_activated ) {
+				$url = home_url();
+			}
 
 			remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
 

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -240,19 +240,19 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		 * Returns the correct url.
 		 */
 		public function get_home_url() {
-		    if ( ! is_multisite() ) {
-                // Add a new filter to undo WPML's changing of home url.
-			    add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
+			if ( ! is_multisite() ) {
+				// Add a new filter to undo WPML's changing of home url.
+				add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
 
-			    $home_url = home_url();
+				$home_url = home_url();
 
-			    remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
+				remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
 
-			    return $home_url;
-            }
-            // WPML does not change the network home url so we can return it without modification.
-		    return network_home_url();
-        }
+				return $home_url;
+			}
+			// WPML does not change the network home url so we can return it without modification.
+			return network_home_url();
+		}
 
 		/**
 		 * Returns the original URL instead of the language-enriched URL.

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -243,27 +243,15 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		 * In case of no multisite setup we return the home_url while overriding the WPML filter.
 		 */
 		public function get_url() {
-			if ( is_multisite() ) {
-				// WPML does not change the network home url so we can return it without modification.
-				return network_home_url();
-			}
-			return $this->get_home_url();
-		}
-
-		/**
-		 * Returns the real home url without any WPML language additions.
-		 *
-		 * @return string The home url.
-		 */
-		protected function get_home_url() {
 			// Add a new filter to undo WPML's changing of home url.
 			add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
 
-			$home_url = home_url();
+			// Network home url will return home url for non-network installs.
+			$url = network_home_url();
 
 			remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
 
-			return $home_url;
+			return $url;
 		}
 
 		/**

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -255,7 +255,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 		 *
 		 * @return string The home url.
 		 */
-		public function get_home_url() {
+		protected function get_home_url() {
 			// Add a new filter to undo WPML's changing of home url.
 			add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
 

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -268,9 +268,7 @@ if ( ! class_exists( 'Yoast_License_Manager', false ) ) {
 
 		/**
 		 * Returns the original URL instead of the language-enriched URL.
-		 *
-		 * This method is trigger by filter wpml_get_home_url and returns the $url this is the url before the filter
-		 * has been executed and can be considered as the one that isn't altered by WPML.
+		 * This method gets automatically triggered by the wpml_get_home_url filter.
 		 *
 		 * @param string $home_url The url altered by WPML. Unused.
 		 * @param string $url      The url that isn't altered by WPML.

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -111,7 +111,7 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 				'item_name'    => $this->product->get_item_name(),
 				'wp_version'   => $wp_version,
 				'item_version' => $this->product->get_version(),
-				'url'          => $this->license_manager->get_home_url(),
+				'url'          => $this->license_manager->get_url(),
 				'slug'         => $this->product->get_slug(),
 			);
 

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -111,7 +111,7 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 				'item_name'    => $this->product->get_item_name(),
 				'wp_version'   => $wp_version,
 				'item_version' => $this->product->get_version(),
-				'url'          => $this->get_home_url(),
+				'url'          => $this->license_manager->get_home_url(),
 				'slug'         => $this->product->get_slug(),
 			);
 
@@ -217,37 +217,6 @@ if ( ! class_exists( "Yoast_Update_Manager", false ) ) {
 			}
 
 			return false;
-		}
-
-		/**
-		 * Returns the real home url without any WPML language additions.
-		 *
-		 * @return string The home url.
-		 */
-		private function get_home_url() {
-
-			add_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10, 2 );
-
-			$home_url = home_url();
-
-			remove_filter( 'wpml_get_home_url', array( $this, 'wpml_get_home_url' ), 10 );
-
-			return $home_url;
-		}
-
-		/**
-		 * Returns the original URL instead of the language-enriched URL.
-		 *
-		 * This method is trigger by filter wpml_get_home_url and returns the $url this is the url before the filter
-		 * has been executed and can be considered as the one that isn't altered by WPML.
-		 *
-		 * @param string $home_url The url altered by WPML. Unused.
-		 * @param string $url      The url that isn't altered by WPML.
-		 *
-		 * @return string The original url.
-		 */
-		public function wpml_get_home_url( $home_url, $url ) {
-			return $url;
 		}
 
 	}


### PR DESCRIPTION
Creates a consistent `get_home_url` function used by both the license and update manager.

If we're dealing with a multisite it calls `network_home_url`. If it's not a multisite it adds a filter previously only used in the update manager to filter out changes by WPML and then calls `home_url` before removing said filter again. This filter is not needed for `network_home_url` as WPML does not add any filters there.


## Test instructions

This PR can be tested by following these steps:

* On a normal WordPress site the `get_url` function should simply return domain of the site.
* On a multisite WordPress site the `get_url` function should return the domain of the network.
* On a WordPress site where the frontend and admin are available on different domains the `get_url` function should return the domain of the frontend.

Fixes #58.
Fixes #70.