### PR TITLE
.gitattributes: document and update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,28 @@
-tests 			export-ignore
-.gitattributes 	export-ignore
-.gitignore 		export-ignore
-.travis.yml 	export-ignore
-package.json 	export-ignore
-phpunit.xml 	export-ignore
-README.md 		export-ignore
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for this module using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+
+tests           export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+.phpcs.xml.dist export-ignore
+.phpcs.xml      export-ignore
+.travis.yml     export-ignore
+phpcs.xml       export-ignore
+phpunit.xml     export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
* Add documentation to the sections.
* Remove the `package.json` and `README.md` references from the `export-ignore` section.
    - Readme should be part of the distributed package so people know how to use the package.
    - `package.json` does not exist in this repo.
* Add end-of-line character normalization.