### PR TITLE
Composer: use a valid license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Yoast License Manager.",
     "keywords"   : ["wordpress"],
     "homepage"   : "https://github.com/Yoast/License-Manager",
-    "license"    : "GPL-2.0+",
+    "license"    : "GPL-2.0-or-later",
     "authors"    : [
         {
             "name"    : "Team Yoast",


### PR DESCRIPTION
As of Composer 1.6.0, the SPDX license identifiers v3.0 for GPL/LGPL/AGPL are supported and the old license identifiers are deprecated.

Refs:
* https://github.com/composer/composer/releases/tag/1.6.0
* https://spdx.org/news/news/2018/01/license-list-30-released