### PR TITLE
CS: fix array declaration formats

### DIFF
--- a/class-api-request.php
+++ b/class-api-request.php
@@ -16,13 +16,13 @@ if ( ! class_exists( 'Yoast_API_Request_v2', false ) ) {
 		* @var array Request parameters
 		*/
 		private $args = array(
-			'method' => 'GET',
-			'timeout' => 10,
+			'method'    => 'GET',
+			'timeout'   => 10,
 			'sslverify' => false,
-			'headers' => array(
+			'headers'   => array(
 				'Accept-Encoding' => '*',
-				'X-Yoast-EDD' => '1'
-			)
+				'X-Yoast-EDD'     => '1',
+			),
 		);
 
 		/**

--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -291,7 +291,7 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 				'edd_action' => $action . '_license',
 				'license'    => $this->get_license_key(),
 				'item_name'  => urlencode( trim( $this->product->get_item_name() ) ),
-				'url'        => $this->get_url()
+				'url'        => $this->get_url(),
 				// grab the URL straight from the option to prevent filters from breaking it.
 			);
 
@@ -396,7 +396,7 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 			$defaults = array(
 				'key'         => '',
 				'status'      => '',
-				'expiry_date' => ''
+				'expiry_date' => '',
 			);
 
 			// merge options with defaults
@@ -748,10 +748,10 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 			// Make sure we limit the type of HTML elements to be displayed.
 			if ( ! empty( $message ) ) {
 				$message = wp_kses( $message, array(
-					'a' => array(
+					'a'  => array(
 						'href'   => array(),
 						'target' => array(),
-						'title'  => array()
+						'title'  => array(),
 					),
                     'br' => array(),
 				) );

--- a/class-product.php
+++ b/class-product.php
@@ -306,7 +306,7 @@ if ( ! class_exists( 'Yoast_Product_v2', false ) ) {
 				'utm_campaign' => $this->get_item_name() . ' licensing',
 				'utm_medium'   => 'link',
 				'utm_source'   => $this->get_item_name(),
-				'utm_content'  => $link_identifier
+				'utm_content'  => $link_identifier,
 			);
 
 			// URL encode tracking vars.

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'Yoast_Update_Manager_v2', false ) ) {
 			// setup request parameters
 			$request_params = array(
 				'method' => 'POST',
-				'body'   => $api_params
+				'body'   => $api_params,
 			);
 
 			require_once dirname( __FILE__ ) . '/class-api-request.php';

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -85,7 +85,10 @@ class Yoast_License_Manager_Double extends Yoast_License_Manager_v2 {
 	 * @todo mock this instead
 	 */
 	protected function set_notice( $message, $success = true ) {
-		$this->__notices[] = array( 'message' => $message, 'success' => $success );
+		$this->__notices[] = array(
+			'message' => $message,
+			'success' => $success,
+		);
 	}
 
 	/**
@@ -162,7 +165,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$api_response = (object) array(
 			'license_limit' => 0,
-			'expiry_date'   => false
+			'expiry_date'   => false,
 		);
 
 		$message = 'Your test-product license has been activated. ';
@@ -182,7 +185,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$api_response = (object) array(
 			'license_limit' => 8,
 			'site_count'    => 2,
-			'expires'       => false
+			'expires'       => false,
 		);
 
 		$message = 'Your test-product license has been activated. ';
@@ -202,7 +205,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$api_response = (object) array(
 			'site_count'    => 2,
 			'license_limit' => 3,
-			'expires'       => false
+			'expires'       => false,
 		);
 
 		$message = 'Your test-product license has been activated. ';
@@ -224,7 +227,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$api_response = (object) array(
 			'license_limit' => 0,
-			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) )
+			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) ),
 		);
 
 		$message = 'Your test-product license has been activated. ';
@@ -246,7 +249,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$api_response = (object) array(
 			'license_limit' => 0,
-			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) )
+			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) ),
 		);
 
 		$message = 'Your test-product license has been activated. ';
@@ -269,7 +272,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$api_response = (object) array(
 			'site_count'    => 2,
 			'license_limit' => 3,
-			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) )
+			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) ),
 		);
 
 		$message = 'Your test-product license has been activated. ';
@@ -290,7 +293,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 */
 	public function test_get_unsuccessful_activation_message() {
 		$api_response = (object) array(
-			'error' => ''
+			'error' => '',
 		);
 
 		$message = 'Failed to activate your license, your license key seems to be invalid.';
@@ -307,7 +310,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 */
 	public function test_get_unsuccessful_activation_message_no_activations_left() {
 		$api_response = (object) array(
-			'error' => 'no_activations_left'
+			'error' => 'no_activations_left',
 		);
 
 		$message = sprintf( 'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.', $this->class->product->get_extension_url( 'license-at-limit-notice' ) );
@@ -324,7 +327,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 */
 	public function test_get_unsuccessful_activation_message_expired() {
 		$api_response = (object) array(
-			'error' => 'expired'
+			'error' => 'expired',
 		);
 
 		$message = sprintf( 'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.', $this->class->product->get_extension_url( 'license-expired-notice' ) );
@@ -362,7 +365,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$locale = $this->class->get_user_locale();
 
 		$api_response = (object) array(
-			'custom_message_' . $locale => $message
+			'custom_message_' . $locale => $message,
 		);
 
 		$result = $this->class->get_custom_message( $api_response );
@@ -408,8 +411,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertEquals( array(
 			array(
 				'message' => $message,
-				'success' => true
-			)
+				'success' => true,
+			),
 		), $this->class->__get_notices() );
 	}
 
@@ -422,7 +425,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$api_response = (object) array(
 			'license'        => 'valid',
 			'license_limit'  => 0,
-			'custom_message' => 'This is an HTML description.'
+			'custom_message' => 'This is an HTML description.',
 		);
 
 
@@ -435,8 +438,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertEquals( array(
 			array(
 				'message' => $message . '<br />' . $api_response->custom_message,
-				'success' => true
-			)
+				'success' => true,
+			),
 		), $this->class->__get_notices() );
 	}
 
@@ -465,7 +468,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 */
 	public function test_deactivate_license_success() {
 		$api_response = (object) array(
-			'license' => 'deactivated'
+			'license' => 'deactivated',
 		);
 
 		$message = 'Your test-product license has been deactivated.';
@@ -477,8 +480,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertEquals( array(
 			array(
 				'message' => $message,
-				'success' => true
-			)
+				'success' => true,
+			),
 		), $this->class->__get_notices() );
 	}
 
@@ -490,7 +493,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_deactivate_license_success_custom_message() {
 		$api_response = (object) array(
 			'license'        => 'deactivated',
-			'custom_message' => 'This is an HTML description.'
+			'custom_message' => 'This is an HTML description.',
 		);
 
 		$message = 'Your test-product license has been deactivated.';
@@ -502,8 +505,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertEquals( array(
 			array(
 				'message' => $message . '<br />' . $api_response->custom_message,
-				'success' => true
-			)
+				'success' => true,
+			),
 		), $this->class->__get_notices() );
 	}
 
@@ -514,7 +517,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	 */
 	public function test_deactivate_license_failed() {
 		$api_response = (object) array(
-			'license' => 'activated' // Expected to be deactivated.
+			'license' => 'activated', // Expected to be deactivated.
 		);
 
 		$message = 'Failed to deactivate your test-product license.';
@@ -526,8 +529,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertEquals( array(
 			array(
 				'message' => $message,
-				'success' => false
-			)
+				'success' => false,
+			),
 		), $this->class->__get_notices() );
 	}
 
@@ -539,7 +542,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 	public function test_deactivate_license_failed_custom_message() {
 		$api_response = (object) array(
 			'license'        => 'activated', // Expected to be deactivated.
-			'custom_message' => 'This is an HTML description.'
+			'custom_message' => 'This is an HTML description.',
 		);
 
 		$message = 'Failed to deactivate your test-product license.';
@@ -551,8 +554,8 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->assertEquals( array(
 			array(
 				'message' => $message . '<br />' . $api_response->custom_message,
-				'success' => false
-			)
+				'success' => false,
+			),
 		), $this->class->__get_notices() );
 	}
 
@@ -565,7 +568,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$message = 'Normal HTML Message with a <a href="http://example.com">link</a>.';
 
 		$api_response = (object) array(
-			'custom_message' => $message
+			'custom_message' => $message,
 		);
 
 		$result = $this->class->get_custom_message( $api_response );
@@ -583,7 +586,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$expected = 'Normal HTML Message<br /> with a <a href="http://example.com" target="_blank" title="bla">link</a>.';
 
 		$api_response = (object) array(
-			'custom_message' => $message
+			'custom_message' => $message,
 		);
 
 		$result = $this->class->get_custom_message( $api_response );
@@ -601,7 +604,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$expected = 'Normal HTML Message with a link.';
 
 		$api_response = (object) array(
-			'custom_message' => $message
+			'custom_message' => $message,
 		);
 
 		$result = $this->class->get_custom_message( $api_response );


### PR DESCRIPTION
Fixes related to arrays declarations, which should comply with the following rules:
* Associative arrays with more than one item should be multi-line, with each item starting on a new line.
* There should be a comma after each item in a multi-line array declaration.
* The double arrows in multi-line array declarations should be aligned.

This PR contains **no** functional changes.