### PR TITLE
QA: review of all include and require statements

### DIFF
--- a/class-plugin-license-manager.php
+++ b/class-plugin-license-manager.php
@@ -17,7 +17,7 @@ if ( class_exists( 'Yoast_License_Manager_v2' ) && ! class_exists( 'Yoast_Plugin
 			if( is_admin() && is_multisite() ) {
 
 				if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-					require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
 				}
 
 				$this->is_network_activated = is_plugin_active_for_network( $product->get_file() );
@@ -35,8 +35,8 @@ if ( class_exists( 'Yoast_License_Manager_v2' ) && ! class_exists( 'Yoast_Plugin
 			 */
 			if ( apply_filters( 'yoast-license-valid', $this->license_is_valid() ) ) {
 				// setup auto updater
-				require_once( dirname( __FILE__ ) . '/class-update-manager.php' );
-				require_once( dirname( __FILE__ ) . '/class-plugin-update-manager.php' );
+				require_once dirname( __FILE__ ) . '/class-update-manager.php';
+				require_once dirname( __FILE__ ) . '/class-plugin-update-manager.php';
 				new Yoast_Plugin_Update_Manager_v2( $this->product, $this );
 			}
 		}

--- a/class-product.php
+++ b/class-product.php
@@ -153,7 +153,7 @@ if ( ! class_exists( 'Yoast_Product_v2', false ) ) {
 			if ( is_admin() && is_multisite() ) {
 
 				if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-					require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
 				}
 
 				if ( is_plugin_active_for_network( $this->get_file() ) ) {

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -1,7 +1,7 @@
 <?php
 
-include dirname( __FILE__ ) . '../../class-product.php';
-include dirname( __FILE__ ) . '../../class-license-manager.php';
+require_once dirname( __FILE__ ) . '/../../class-product.php';
+require_once dirname( __FILE__ ) . '/../../class-license-manager.php';
 
 /**
  * Class Yoast_Product_Double


### PR DESCRIPTION
`include` and `require` are language constructs, not functions.

With that in mind there are a number of best practices surrounding them:
* There is no need to use parenthesis and not doing so will be, albeit marginally,  faster.
* Always pass an absolute path for maximum portability.
* Mind the slashes.  WP defines `ABSPATH` includes trailing slash. The PHP native `dirname( __FILE__ )` does not contain a trailing slash.
* If a file is included unconditionally, it is better to use `require(_once)`. When `include` doesn't find a file, it will throw a warning and try to continue executing the file. When `require` doesn't find a file, it will stop execution of the script with a fatal error.

**Note**: This PR contains functional changes and should be tested, though no problems are expected.
(working Travis build testing would help here, but that's another matter).