### PR TITLE
QA: Use strict comparisons [1]

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -130,7 +130,7 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 
 			// show notice if license is invalid
 			if ( $this->show_license_notice() && ! $this->license_is_valid() ) {
-				if ( $this->get_license_key() == '' ) {
+				if ( $this->get_license_key() === '' ) {
 					$message = __( '<b>Warning!</b> You didn\'t set your %s license key yet, which means you\'re missing out on updates and support! <a href="%s">Enter your license key</a> or <a href="%s" target="_blank">get a license here</a>.' );
 				} else {
 					$message = __( '<b>Warning!</b> Your %s license is inactive which means you\'re missing out on updates and support! <a href="%s">Activate your license</a> or <a href="%s" target="_blank">get a license here</a>.' );

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -149,7 +149,7 @@ if ( ! class_exists( 'Yoast_Update_Manager_v2', false ) ) {
 			$response = $request->get_response();
 
 			// check if response returned that a given site was inactive
-			if ( isset( $response->license_check ) && ! empty( $response->license_check ) && $response->license_check != 'valid' ) {
+			if ( isset( $response->license_check ) && ! empty( $response->license_check ) && $response->license_check !== 'valid' ) {
 
 				// deactivate local license
 				$this->license_manager->set_license_status( 'invalid' );


### PR DESCRIPTION
Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

This is especially important when comparing variables which are expected to be strings, as when one of the two operands - for whatever reason, other plugins interfering, errors etc - is not a string, the other operand will be juggled to the type of the first operand which can lead to unexpected results and hard to debug bugs.

Ref: http://phpcheatsheets.com/compare/equal/

**Note**: This is a functional change and should be tested, though no problem are expected.