### PR TITLE
QA: use `wp_parse_url()` instead of `parse_url()`

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 			if ( defined( "WP_HTTP_BLOCK_EXTERNAL" ) && WP_HTTP_BLOCK_EXTERNAL === true ) {
 
 				// check if our API endpoint is in the allowed hosts
-				$host = parse_url( $this->product->get_api_url(), PHP_URL_HOST );
+				$host = wp_parse_url( $this->product->get_api_url(), PHP_URL_HOST );
 
 				if ( ! defined( "WP_ACCESSIBLE_HOSTS" ) || stristr( WP_ACCESSIBLE_HOSTS, $host ) === false ) {
 					?>


### PR DESCRIPTION
The PHP native `parse_url()` function behaves differently across PHP versions which can lead to unexpected results.

WP offers a cross-PHP-version compatible alternative `wp_parse_url()` which is recommended to use instead.

As of WP 4.7, the WP function supports the `$component` parameter as well and as the minimum WP requirements for the Yoast plugins have gone up to WP 4.8, this call to the PHP `parse_url()` function can be replaced with a call to `wp_parse_url()`.

Refs:
* https://developer.wordpress.org/reference/functions/wp_parse_url/
* http://php.net/manual/en/function.parse-url.php

**Note**: This is a functional change and should be tested, though no problem are expected.