### PR TITLE
CS: no multiple assignments in one statement

### DIFF
--- a/tests/framework/class-yst-license-manager-unit-test-case.php
+++ b/tests/framework/class-yst-license-manager-unit-test-case.php
@@ -10,7 +10,8 @@ class Yst_License_Manager_UnitTestCase extends WP_UnitTestCase {
 	 * @param mixed $value
 	 */
 	protected function set_post( $key, $value ) {
-		$_POST[ $key ] = $_REQUEST[ $key ] = addslashes( $value );
+		$_POST[ $key ]    = addslashes( $value );
+		$_REQUEST[ $key ] = $_POST[ $key ];
 	}
 
 	/**


### PR DESCRIPTION
Multiple assignments in one statement makes for harder to debug, harder to read code and is considered a code smell.

### Testing

This is a code-only change and should be safe to merge without extensive testing.