### PR TITLE
CS: use brackets around arithmetic and comparison operations

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -483,7 +483,7 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 			$obfuscate = ( strlen( $this->get_license_key() ) > 5 && ( $this->license_is_valid() || ! $this->remote_license_activation_failed ) );
 
 			if ( $obfuscate ) {
-				$visible_license_key = str_repeat( '*', strlen( $this->get_license_key() ) - 4 ) . substr( $this->get_license_key(), - 4 );
+				$visible_license_key = str_repeat( '*', ( strlen( $this->get_license_key() ) - 4 ) ) . substr( $this->get_license_key(), - 4 );
 			}
 
 			// make license key readonly when license key is valid or license is defined with a constant

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -227,7 +227,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$api_response = (object) array(
 			'license_limit' => 0,
-			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) ),
+			'expires'       => date( DATE_RSS, ( time() + ( $days_left * 86400 ) ) ),
 		);
 
 		$message  = 'Your test-product license has been activated. ';
@@ -249,7 +249,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$api_response = (object) array(
 			'license_limit' => 0,
-			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) ),
+			'expires'       => date( DATE_RSS, ( time() + ( $days_left * 86400 ) ) ),
 		);
 
 		$message  = 'Your test-product license has been activated. ';
@@ -272,7 +272,7 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$api_response = (object) array(
 			'site_count'    => 2,
 			'license_limit' => 3,
-			'expires'       => date( DATE_RSS, time() + ( $days_left * 86400 ) ),
+			'expires'       => date( DATE_RSS, ( time() + ( $days_left * 86400 ) ) ),
 		);
 
 		$message  = 'Your test-product license has been activated. ';


### PR DESCRIPTION
When using arithmetics and more complex comparisons, [PHP operator precedence](http://php.net/manual/en/language.operators.precedence.php) comes into play.

To prevent issues caused by quirks in operator precedence, it is better to surround these kind of operations with parenthesis.

### Testing

This is a code-only change and should be safe to merge without extensive testing.