### PR TITLE
CS: Move multi-line parameters out of function calls [1]

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -750,14 +750,15 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 
 			// Make sure we limit the type of HTML elements to be displayed.
 			if ( ! empty( $message ) ) {
-				$message = wp_kses( $message, array(
+				$allowed_html = array(
 					'a'  => array(
 						'href'   => array(),
 						'target' => array(),
 						'title'  => array(),
 					),
 					'br' => array(),
-				) );
+				);
+				$message      = wp_kses( $message, $allowed_html );
 
 				// Make sure we are on a new line.
 				$message = '<br />' . $message;

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -407,12 +407,13 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->class->set_license_api_response( 'activate', $api_response );
 		$this->class->activate_license();
 
-		$this->assertEquals( array(
+		$expected = array(
 			array(
 				'message' => $message,
 				'success' => true,
 			),
-		), $this->class->__get_notices() );
+		);
+		$this->assertEquals( $expected, $this->class->__get_notices() );
 	}
 
 	/**
@@ -434,12 +435,13 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->class->set_license_api_response( 'activate', $api_response );
 		$this->class->activate_license();
 
-		$this->assertEquals( array(
+		$expected = array(
 			array(
 				'message' => $message . '<br />' . $api_response->custom_message,
 				'success' => true,
 			),
-		), $this->class->__get_notices() );
+		);
+		$this->assertEquals( $expected, $this->class->__get_notices() );
 	}
 
 	/**
@@ -476,12 +478,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertTrue( $this->class->deactivate_license() );
-		$this->assertEquals( array(
+
+		$expected = array(
 			array(
 				'message' => $message,
 				'success' => true,
 			),
-		), $this->class->__get_notices() );
+		);
+		$this->assertEquals( $expected, $this->class->__get_notices() );
 	}
 
 	/**
@@ -501,12 +505,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertTrue( $this->class->deactivate_license() );
-		$this->assertEquals( array(
+
+		$expected = array(
 			array(
 				'message' => $message . '<br />' . $api_response->custom_message,
 				'success' => true,
 			),
-		), $this->class->__get_notices() );
+		);
+		$this->assertEquals( $expected, $this->class->__get_notices() );
 	}
 
 	/**
@@ -525,12 +531,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertFalse( $this->class->deactivate_license() );
-		$this->assertEquals( array(
+
+		$expected = array(
 			array(
 				'message' => $message,
 				'success' => false,
 			),
-		), $this->class->__get_notices() );
+		);
+		$this->assertEquals( $expected, $this->class->__get_notices() );
 	}
 
 	/**
@@ -550,12 +558,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 		$this->class->set_license_api_response( 'deactivate', $api_response );
 
 		$this->assertFalse( $this->class->deactivate_license() );
-		$this->assertEquals( array(
+
+		$expected = array(
 			array(
 				'message' => $message . '<br />' . $api_response->custom_message,
 				'success' => false,
 			),
-		), $this->class->__get_notices() );
+		);
+		$this->assertEquals( $expected, $this->class->__get_notices() );
 	}
 
 	/**


### PR DESCRIPTION
WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be  introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding- Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding- Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently  already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have  been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and  defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

### Testing

This is a code-only change and should be safe to merge without extensive testing.