### PR TITLE
QA: Use strict comparisons [2]

### DIFF
--- a/class-plugin-license-manager.php
+++ b/class-plugin-license-manager.php
@@ -84,7 +84,7 @@ if ( class_exists( 'Yoast_License_Manager_v2' ) && ! class_exists( 'Yoast_Plugin
 				}
 			}
 			else {
-				if ( false == is_network_admin() ) {
+				if ( false === is_network_admin() ) {
 					parent::show_license_form( $embedded );
 				}
 			}


### PR DESCRIPTION
Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

As the output of `is_network_admin()` is always supposed to be a boolean, a strict comparison can be used here without issue.

Ref: https://developer.wordpress.org/reference/functions/is_network_admin/

### Testing

This is a code-only change and should be safe to merge without extensive testing.