### PR TITLE
CS: function call formatting

### DIFF
--- a/class-license-manager.php
+++ b/class-license-manager.php
@@ -139,7 +139,16 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 				}
 				?>
 				<div class="notice notice-error yoast-notice-error">
-					<p><?php printf( __( $message, $this->product->get_text_domain() ), $this->product->get_item_name(), $this->product->get_license_page_url(), $this->product->get_tracking_url( 'activate-license-notice' ) ); ?></p>
+					<p>
+						<?php
+						printf(
+							__( $message, $this->product->get_text_domain() ),
+							$this->product->get_item_name(),
+							$this->product->get_license_page_url(),
+							$this->product->get_tracking_url( 'activate-license-notice' )
+						);
+						?>
+					</p>
 				</div>
 				<?php
 			}
@@ -153,7 +162,16 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 				if ( ! defined( 'WP_ACCESSIBLE_HOSTS' ) || stristr( WP_ACCESSIBLE_HOSTS, $host ) === false ) {
 					?>
 					<div class="notice notice-error yoast-notice-error">
-						<p><?php printf( __( '<b>Warning!</b> You\'re blocking external requests which means you won\'t be able to get %s updates. Please add %s to %s.', $this->product->get_text_domain() ), $this->product->get_item_name(), '<strong>' . $host . '</strong>', '<code>WP_ACCESSIBLE_HOSTS</code>' ); ?></p>
+						<p>
+							<?php
+							printf(
+								__( '<b>Warning!</b> You\'re blocking external requests which means you won\'t be able to get %s updates. Please add %s to %s.', $this->product->get_text_domain() ),
+								$this->product->get_item_name(),
+								'<strong>' . $host . '</strong>',
+								'<code>WP_ACCESSIBLE_HOSTS</code>'
+							);
+							?>
+						</p>
 					</div>
 					<?php
 				}
@@ -219,11 +237,17 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 				// show notice if license is deactivated
 				if ( $result->license === 'deactivated' ) {
 					$success = true;
-					$message = sprintf( __( 'Your %s license has been deactivated.', $this->product->get_text_domain() ), $this->product->get_item_name() );
+					$message = sprintf(
+						__( 'Your %s license has been deactivated.', $this->product->get_text_domain() ),
+						$this->product->get_item_name()
+					);
 				}
 				else {
 					$success = false;
-					$message = sprintf( __( 'Failed to deactivate your %s license.', $this->product->get_text_domain() ), $this->product->get_item_name() );
+					$message = sprintf(
+						__( 'Failed to deactivate your %s license.', $this->product->get_text_domain() ),
+						$this->product->get_item_name()
+					);
 				}
 
 				$message .= $this->get_custom_message( $result );
@@ -459,7 +483,12 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 		public function show_license_form_heading() {
 			?>
 			<h3>
-				<?php printf( __( '%s: License Settings', $this->product->get_text_domain() ), $this->product->get_item_name() ); ?>
+				<?php
+				printf(
+					__( '%s: License Settings', $this->product->get_text_domain() ),
+					$this->product->get_item_name()
+				);
+				?>
 				&nbsp; &nbsp;
 			</h3>
 			<?php
@@ -664,25 +693,39 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 			}
 
 			// Always show that it was successful.
-			$message = sprintf( __( 'Your %s license has been activated. ', $this->product->get_text_domain() ), $this->product->get_item_name() );
+			$message = sprintf(
+				__( 'Your %s license has been activated. ', $this->product->get_text_domain() ),
+				$this->product->get_item_name()
+			);
 
 			// Show a custom notice it is an unlimited license.
 			if ( $result->license_limit == 0 ) {
 				$message .= __( 'You have an unlimited license. ', $this->product->get_text_domain() );
 			}
 			else {
-				$message .= sprintf( _n( 'You have used %d/%d activation. ', 'You have used %d/%d activations. ', $result->license_limit, $this->product->get_text_domain() ), $result->site_count, $result->license_limit );
+				$message .= sprintf(
+					_n( 'You have used %d/%d activation. ', 'You have used %d/%d activations. ', $result->license_limit, $this->product->get_text_domain() ),
+					$result->site_count,
+					$result->license_limit
+				);
 			}
 
 			// add upgrade notice if user has less than 3 activations left
 			if ( $result->license_limit > 0 && ( $result->license_limit - $result->site_count ) <= 3 ) {
-				$message .= sprintf( __( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-nearing-limit-notice' ) );
+				$message .= sprintf(
+					__( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->product->get_text_domain() ),
+					$this->product->get_extension_url( 'license-nearing-limit-notice' )
+				);
 			}
 
 			if ( $expiry_date !== false && $expiry_date < strtotime( '+1 month' ) ) {
 				// Add extend notice if license is expiring in less than 1 month.
 				$days_left = round( ( $expiry_date - time() ) / 86400 );
-				$message  .= sprintf( _n( '<a href="%s">Your license is expiring in %d day, would you like to extend it?</a> ', '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $days_left, $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-expiring-notice' ), $days_left );
+				$message  .= sprintf(
+					_n( '<a href="%s">Your license is expiring in %d day, would you like to extend it?</a> ', '<a href="%s">Your license is expiring in %d days, would you like to extend it?</a> ', $days_left, $this->product->get_text_domain() ),
+					$this->product->get_extension_url( 'license-expiring-notice' ),
+					$days_left
+				);
 			}
 
 			return $message;
@@ -703,12 +746,18 @@ if ( ! class_exists( 'Yoast_License_Manager_v2', false ) ) {
 				switch ( $result->error ) {
 					// Show notice if user is at their activation limit.
 					case 'no_activations_left':
-						$message = sprintf( __( 'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.', $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-at-limit-notice' ) );
+						$message = sprintf(
+							__( 'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.', $this->product->get_text_domain() ),
+							$this->product->get_extension_url( 'license-at-limit-notice' )
+						);
 						break;
 
 					// Show notice if the license is expired.
 					case 'expired':
-						$message = sprintf( __( 'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.', $this->product->get_text_domain() ), $this->product->get_extension_url( 'license-expired-notice' ) );
+						$message = sprintf(
+							__( 'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.', $this->product->get_text_domain() ),
+							$this->product->get_extension_url( 'license-expired-notice' )
+						);
 						break;
 				}
 			}

--- a/class-plugin-license-manager.php
+++ b/class-plugin-license-manager.php
@@ -76,10 +76,21 @@ if ( class_exists( 'Yoast_License_Manager_v2' ) && ! class_exists( 'Yoast_Plugin
 					// We're not in the network admin area, show a notice
 					parent::show_license_form_heading();
 					if ( is_super_admin() ) {
-						echo '<p>' . sprintf( __( '%s is network activated, you can manage your license in the <a href="%s">network admin license page</a>.', $this->product->get_text_domain() ), $this->product->get_item_name(), $this->product->get_license_page_url() ) . '</p>';
+						echo '<p>';
+						printf(
+							__( '%s is network activated, you can manage your license in the <a href="%s">network admin license page</a>.', $this->product->get_text_domain() ),
+							$this->product->get_item_name(),
+							$this->product->get_license_page_url()
+						);
+						echo '</p>';
 					}
 					else {
-						echo '<p>' . sprintf( __( '%s is network activated, please contact your site administrator to manage the license.', $this->product->get_text_domain() ), $this->product->get_item_name() ) . '</p>';
+						echo '<p>';
+						printf(
+							__( '%s is network activated, please contact your site administrator to manage the license.', $this->product->get_text_domain() ),
+							$this->product->get_item_name()
+						);
+						echo '</p>';
 					}
 				}
 			}

--- a/class-theme-license-manager.php
+++ b/class-theme-license-manager.php
@@ -31,7 +31,13 @@ if ( class_exists( 'Yoast_License_Manager_v2' ) && ! class_exists( 'Yoast_Theme_
 		 * Add license page and add it to Themes menu
 		 */
 		public function add_license_menu() {
-			add_theme_page( sprintf( __( '%s License', $this->product->get_text_domain() ), $this->product->get_item_name() ), __( 'Theme License', $this->product->get_text_domain() ), 'manage_options', 'theme-license', array( $this, 'show_license_page' ) );
+			add_theme_page(
+				sprintf( __( '%s License', $this->product->get_text_domain() ), $this->product->get_item_name() ),
+				__( 'Theme License', $this->product->get_text_domain() ),
+				'manage_options',
+				'theme-license',
+				array( $this, 'show_license_page' )
+			);
 		}
 
 		/**

--- a/class-theme-update-manager.php
+++ b/class-theme-update-manager.php
@@ -88,7 +88,10 @@ if ( class_exists( 'Yoast_Update_Manager_v2' ) && ! class_exists( 'Yoast_Theme_U
 				return;
 			}
 
-			$update_url     = wp_nonce_url( 'update.php?action=upgrade-theme&amp;theme=' . urlencode( $this->product->get_slug() ), 'upgrade-theme_' . $this->product->get_slug() );
+			$update_url     = wp_nonce_url(
+				'update.php?action=upgrade-theme&amp;theme=' . urlencode( $this->product->get_slug() ),
+				'upgrade-theme_' . $this->product->get_slug()
+			);
 			$update_onclick = ' onclick="if ( confirm(\'' . esc_js( __( "Updating this theme will lose any customizations you have made. 'Cancel' to stop, 'OK' to update." ) ) . '\') ) {return true;}return false;"';
 			?>
 			<div id="update-nag">

--- a/class-update-manager.php
+++ b/class-update-manager.php
@@ -76,7 +76,15 @@ if ( ! class_exists( 'Yoast_Update_Manager_v2', false ) ) {
 
 			?>
 			<div class="notice notice-error yoast-notice-error">
-				<p><?php printf( __( '%s failed to check for updates because of the following error: <em>%s</em>', $this->product->get_text_domain() ), $this->product->get_item_name(), $this->error_message ); ?></p>
+				<p>
+					<?php
+					printf(
+						__( '%s failed to check for updates because of the following error: <em>%s</em>', $this->product->get_text_domain() ),
+						$this->product->get_item_name(),
+						$this->error_message
+					);
+					?>
+				</p>
 			</div>
 			<?php
 		}

--- a/tests/test-class-yoast-license-manager.php
+++ b/tests/test-class-yoast-license-manager.php
@@ -210,7 +210,10 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$message  = 'Your test-product license has been activated. ';
 		$message .= 'You have used 2/3 activations. ';
-		$message .= sprintf( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->class->product->get_extension_url( 'license-nearing-limit-notice' ) );
+		$message .= sprintf(
+			'<a href="%s">Did you know you can upgrade your license?</a> ',
+			$this->class->product->get_extension_url( 'license-nearing-limit-notice' )
+		);
 
 		$result = $this->class->get_successful_activation_message( $api_response );
 
@@ -232,7 +235,10 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$message  = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
-		$message .= sprintf( '<a href="%s">Your license is expiring in 5 days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ) );
+		$message .= sprintf(
+			'<a href="%s">Your license is expiring in 5 days, would you like to extend it?</a> ',
+			$this->class->product->get_extension_url( 'license-expiring-notice' )
+		);
 
 		$result = $this->class->get_successful_activation_message( $api_response );
 
@@ -254,7 +260,10 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$message  = 'Your test-product license has been activated. ';
 		$message .= 'You have an unlimited license. ';
-		$message .= sprintf( '<a href="%s">Your license is expiring in 1 day, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ) );
+		$message .= sprintf(
+			'<a href="%s">Your license is expiring in 1 day, would you like to extend it?</a> ',
+			$this->class->product->get_extension_url( 'license-expiring-notice' )
+		);
 
 		$result = $this->class->get_successful_activation_message( $api_response );
 
@@ -277,8 +286,14 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 
 		$message  = 'Your test-product license has been activated. ';
 		$message .= 'You have used 2/3 activations. ';
-		$message .= sprintf( '<a href="%s">Did you know you can upgrade your license?</a> ', $this->class->product->get_extension_url( 'license-nearing-limit-notice' ) );
-		$message .= sprintf( '<a href="%s">Your license is expiring in 5 days, would you like to extend it?</a> ', $this->class->product->get_extension_url( 'license-expiring-notice' ) );
+		$message .= sprintf(
+			'<a href="%s">Did you know you can upgrade your license?</a> ',
+			$this->class->product->get_extension_url( 'license-nearing-limit-notice' )
+		);
+		$message .= sprintf(
+			'<a href="%s">Your license is expiring in 5 days, would you like to extend it?</a> ',
+			$this->class->product->get_extension_url( 'license-expiring-notice' )
+		);
 
 		$result = $this->class->get_successful_activation_message( $api_response );
 
@@ -312,7 +327,10 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 			'error' => 'no_activations_left',
 		);
 
-		$message = sprintf( 'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.', $this->class->product->get_extension_url( 'license-at-limit-notice' ) );
+		$message = sprintf(
+			'You\'ve reached your activation limit. You must <a href="%s">upgrade your license</a> to use it on this site.',
+			$this->class->product->get_extension_url( 'license-at-limit-notice' )
+		);
 
 		$result = $this->class->get_unsuccessful_activation_message( $api_response );
 
@@ -329,7 +347,10 @@ class Test_Yoast_License_Manager extends Yst_License_Manager_UnitTestCase {
 			'error' => 'expired',
 		);
 
-		$message = sprintf( 'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.', $this->class->product->get_extension_url( 'license-expired-notice' ) );
+		$message = sprintf(
+			'Your license has expired. You must <a href="%s">extend your license</a> in order to use it again.',
+			$this->class->product->get_extension_url( 'license-expired-notice' )
+		);
 
 		$result = $this->class->get_unsuccessful_activation_message( $api_response );
 


### PR DESCRIPTION
When a function call wraps to several lines, it's probably too long. This decreases readability of code and makes it harder to understand.

While YoastCS doesn't (yet) have any hard rules about line length, splitting a long multi-parameter function call up to have each parameter on a new line is good practice.

Notes:
* If the line was an embedded PHP snippet, making it multi-line means that the PHP open/close tags have to be on their own line as well.
    For those cases where that applied in the fixes in this commit, it should not have any visible impact on the HTML output.
    Note: depending on the HTML tag within which such a call is embedded, it can have an impact on the HTML output, so care should be taken when doing this.
* Where an `echo ... sprintf()` was encountered, this has been replaced with echo calls for the plain HTML and `printf()` calls to replace the `sprintf()`.